### PR TITLE
Effect steps

### DIFF
--- a/docs/draft_docs.txt
+++ b/docs/draft_docs.txt
@@ -1,11 +1,11 @@
 Terminology:
 
-Note that "changing the game state" does not include adding things to the queue or otherwise manipulating the internal state of the engine. It means in game state.
+Note that "changing the game state" does not include adding things to the queue or otherwise manipulating the internal state of the engine. It means in game state.  
 
-Effect Step: Basic indivisible units of game state change. Things like drawing cards, gaining credits or the steps of a timing structure fall into this. No other steps may change the game state. 
+Effect Step: Basic indivisible units of game state change. Things like drawing cards, gaining credits or the steps of a timing structure fall into this.  
 Blocking Step: A step that causes the engine to stop what it's doing and wait for something. Usually it'll be waiting on a user because of a prompt. 
-Guard Step: A step that does nothing in itself but that can be aborted to by a special effect step. Each guard step has a keyword type associated with it. 
-Composite Step: All other steps. These steps never do anything other than add steps to the queue, potentially after examining the game state. simple-step gives composite steps.
+Guard Step: A step that is aborted to by the abort step (which is an effect step). Any effect type can be used for this purpose. 
+Composite Step: All other steps. These steps never do anything other than add steps (including effect steps) to the queue, potentially after examining the game state. simple-step gives composite steps.
 Composite Call: A composite step that can be used directly, in addition to queuing it. Composite calls should not depend on game state. Note that the distinction between a composition step and a composite call is in how the revelant function is defined not in how it is used. 
 
 Prompt Step: A blocking step. Displays a custom prompt to the user. 
@@ -14,39 +14,50 @@ Action Step: A blocking step. Represents the action phase ability window.
 
 Interrupt Check Step: A composite step. Represents an interrupt window. 
 
-Checkpoint Step: An effect step. Must be requested manually when required by the engine or cards. Acts as a blocking step for the purposes of the pending instruction.
+Checkpoint Step: An effect step. Must be requested manually when required by the engine or cards. Acts as a blocking step for the purposes of the imminent instruction. 
 Imminent Instruction: The series of steps between the start of the pipeline and the next blocking step or checkpoint step. 
-Expected Effects: The results of a process via which the interrupt system determines which effect steps will run before the next checkpoint.
-
-#I think this is the best way to handle checkpoints and pending instructions.
-
-Pipeline: The pipeline system itself. It just knows how to click prompts, build diffs and run steps.
-Core: The suite supporting functions/macros that allow you to manipulate the pipeline easily. 
-Engine: The game rules. Timing steps, effects and functions for examining the state.
-Cards: The cards.
+Expected Effects: The results of a process via which the interrupt system determines which effect steps will run before the next checkpoint. 
 
 -----------
 
 pipeline Workings:
-The pipeline runs with a simple (swap! @game handle-prompt-clicked action). handle-prompt-clicked will give the action to the prompt at the beginning of the pipeline then call continue-game.
+The pipeline runs with a simple (swap! @game handle-prompt-clicked player action). handle-prompt-clicked will give the action to the prompt at the beginning of the pipeline then call continue-game.
 
-Each invocation other than the first, the kernel expects to be given the action (e.g. prompt click) that caused the invocation. This action is passed to the prompt-clicked method of the first step in the queue prior to the main iteration being performed.
+On each invocation after than the first, the kernel expects to be given the action (e.g. prompt click) that caused the invocation. This action is passed to the prompt-clicked method of the first step in the queue prior to the main iteration being performed.
 
 Each iteration of continue-game performs the following steps:
-Call update-game.
-Call the blocking method of the next step in the queue. If it returns false, continue to the next step, otherwise return whatever the blocking method returned, which should be the game state inc prompt.
-If it returned false, update the game using the continue-step method of the next step and go to the next iteration. 
+Call update-pipeline.
+Call blocking on the next step in the queue. If it returned false, update the game using the continue-step method and go to the next iteration. 
+If it doesn't return false return whatever the blocking method returned, which should be the game state inc prompt.
 
 --------
 
 Engine Workings:
 The majority of engine functions will either be game state reporting functions, which will be hopefully mostly unchanged, or composite steps/calls.
 
-Composite calls mostly follow the form (-> game (step) (step) (step)) and can be defined with a simple defn. They are the simplest and lightest of "steps" in that they needn't be backed by a step record or enter the pipeline at all. Though often they are, which is called a composite step. 
+Composite calls mostly follow the form (-> game (action) (action) (action)) and can be defined with a simple defn. They are the simplest and lightest of "steps" in that they needn't be backed by a step record or enter the pipeline at all. 
 
 Example:
 
 (defn example-composite-call [game some args whatever] (-> game (other-step some args) (more-step whatever)))
+
+If a function examines the game state or recurs, it's known as a composite step and must be defined as a proper step. Like with altering the game state examining the game state is something you must do directly to qualify. A function that draws cards until your hand is full would count because it looks at how many cards you have in hand (i.e. a value that could be altered if there are draw steps in the pipeline). As such this function should be defined as one that queues a step. The effect of the card game day would not count and can be implemented as a simple function, because it can just call that function.
+
+Composite steps that wish to recur must be defined as a proper step and should use (queue-step this) to achieve this. A defn like macro is provided that makes any function a step or the as-step macro provides inline steps. For instance, this function can be safely defined with a simple defn:
+
+(defn simple-call [game] (-> game (blah) (blah) (blah) (as-step (step game (examine-state game))) (blah) (blah) (blah)))
+
+
+Or showing recursion over a prompt:
+
+(-> game (blah) (blah)
+  (as-step (if (mu-limit-exceeded game)
+			   (-> game
+				   (trash-program-prompt)
+				   (queue-step this))
+			   game))
+  (blah) (blah) (blah))
+
 
 As you can see if other-step and more-step were composite calls themselves with similar definitions they'd just immediately have their effect. This is safe because composite steps can only change the pipeline. They have no way to cause triggers or prompts. This means that composite steps are usually expanded before they ever hit the queue. Some composite steps must be true steps, mostly to allow the ablity to (queue-step this) and recur. This method of recursion is the main looping mechanism for the game. 
 

--- a/docs/draft_docs.txt
+++ b/docs/draft_docs.txt
@@ -18,6 +18,10 @@ Checkpoint Step: An effect step. Must be requested manually when required by the
 Imminent Instruction: The series of steps between the start of the pipeline and the next blocking step or checkpoint step. 
 Expected Effects: The results of a process via which the interrupt system determines which effect steps will run before the next checkpoint. 
 
+Core: The pipeline system itself and the related helper functions/macros for interacting with it.
+Engine: The game rules and systems. The dividing line between the core and the engine is that the engine does not interact with the pipeline directly and so can be reasoned about using the rules below.
+Cards: The card code, it follows the same rules as the engine wrt pipeline management.
+
 -----------
 
 Pipeline Workings:
@@ -28,12 +32,32 @@ On each invocation after the first, the kernel expects to be given the action (e
 Each iteration of continue-game performs the following steps:
 Call update-pipeline.
 Call blocking on the next step in the queue. If it returned false, update the game using the continue-step method and go to the next iteration. 
-If it doesn't return false return whatever the blocking method returned, which should be the game state inc prompt.
+If it doesn't return false, return whatever the blocking method returned, which should be the game state inc prompt.
 
 --------
 
 Engine Workings:
-The majority of engine functions will either be game state reporting functions, which will be hopefully mostly unchanged, or composite steps/calls.
+The majority of engine functions will either be game state reporting functions, which will be hopefully mostly unchanged, or composite steps/calls. 
+
+The main advantage of the engine's structure is that it lets you reason about your code as if it were synchronous. If you make the substitutions outlined here, the results will be identical:
+Pretend that queuing a step is running it immediately.
+Pretend that prompts genuinely block.
+Pretend that (queue-step this) is (recur). With the innermost (as-step acting as (loop. If you'd like to recur to an outer as-step, use (as-step (let [named-loop this]...(queue-step named-loop).
+#No arguments to recur atm, might look into this at some point.
+Pretend that (let-step is a weird version of (let that you thread game through, it will then thread game through your bindings and takes results from the last call to (set-result.
+Pretend that the way to get up to date data from game as you're threading it is (as-step rather than ((fn [game].
+Pretend that guard steps and aborting are try/catch blocks. 
+
+With these substitutions any reasoning you make about what will run in what order or what values will be what at which points will be identical to synchronous code with one caveat. If you write:
+
+(defn draw-for-programs 
+	  [game player]
+	  (-> game 
+	      (draw player (programs-in-play game))))
+
+The state that programs-in-play is examining may be stale, much as if you tried to examine it halfway through a thread. This can be avoided by declaring the function with defstep, which simply wraps the function body in (as-step game), which itself wraps around queue-simple-step, providing access to the "this" variable in the process. 
+
+Note that you may still use (let normally when you just want a simple return value rather than a set-result. Just take care that the state of game is up to date by wrapping it in (as-step. 
 
 Composite calls mostly follow the form (-> game (action) (action) (action)) and can be defined with a simple defn. They are the simplest and lightest of "steps" in that they needn't be backed by a step record or enter the pipeline at all. 
 
@@ -41,9 +65,11 @@ Example:
 
 (defn example-composite-call [game some args whatever] (-> game (other-step some args) (more-step whatever)))
 
-If a function examines the game state or recurs, it's known as a composite step and must be defined as a proper step. Like with altering the game state examining the game state is something you must do directly to qualify. A function that draws cards until your hand is full would count because it looks at how many cards you have in hand (i.e. a value that could be altered if there are draw steps in the pipeline). As such this function should be defined as one that queues a step (e.g. via defstep). The effect of the card Game Day would not count and can be implemented as a simple function, because it can just call that function. Likewise, the majority of cards can be implemented as simple functions. 
+If a something examines the game state or recurs, it's known as a composite step and must be defined as a proper step. Like with altering the game state examining the game state is something you must do directly to qualify. A function that draws cards until your hand is full would count because it looks at how many cards you have in hand (i.e. a value that could be altered if there are draw steps in the pipeline). As such this function should be defined as one that queues a step (e.g. via defstep/as-step). The effect of the card Game Day would not count and can be implemented as a simple function, because it can just call that function. Likewise, a good number of cards can be implemented as simple functions. 
 
-Composite steps that wish to recur must be defined as a proper step and should use (queue-step this) to achieve this. A defn like macro defstep is provided that makes any function a step or the as-step macro provides inline steps. For instance, this function can be safely defined with a simple defn:
+We should take care that examinations of state are tightly wrapped in steps, the rule for safety can be summed up as "if you use the game variable other than the normal threading it, you need to wrap that line (i.e. back to where you are threading game) in as-step," just the same as you need to wrap it in ((fn [game] in sync code, though the out of date version you get goes back to the innermost step, not the innermost function. This is mostly moot as the knowledge that any effect could cause any trigger which makes any state change is enough that you always need to do (as-step/fn [game] there anyway. 
+
+Composite steps that wish to recur must be defined as a proper step and should use (queue-step this) to achieve this. Both the defstep and as-step macros bind the variable this (ed note: considering binding something that just lets you recur, "this" shouldn't really be used for anything else). A defn like macro defstep is provided that makes any function a step or the as-step macro provides inline steps. For instance, this function can be safely defined with a simple defn:
 
 (defn simple-call [game] (-> game (blah) (blah) (blah) (as-step (some-effect game (examine-state game))) (blah) (blah) (blah)))
 
@@ -58,7 +84,7 @@ Or showing recursion over a prompt:
 
 
 Prompt Steps:
-Prompts can have any structure really, so long as the users click can be mapped to a step we're good. Prompt steps, like all steps, should have at least one helper function that you can thread game through and get them added to the queue. Prompts are the thing most likely to want to define more functions for different cases. Most stuff should be able to use pretty simple versions though. 
+Prompts can have any structure really, so long as the users click can be mapped to a function we're good. Prompt steps, like all steps, should have at least one helper function that you can thread game through and get them added to the queue. Prompts are the thing most likely to want to define more functions for different cases. Most stuff should be able to use pretty simple versions though. 
 
 PAW Step:
 A prompt step that displays a pass button and activates relevant paid abilities/rezzing etc. 
@@ -79,6 +105,10 @@ After extracting the :expected-effects list from the returned game state the res
 The :expected list is checked against each active interrupt ability for relevance. If none are found, the check is over, disable interrupts (they will be enabled again at the next checkpoint). 
 If some are found, do a standard set of trigger prompts/PAW steps to resolve them, disable interrupts and continue.
 
+------------
+
+Core workings:
+
 defeffect-full macro:
 This macro is used to declare effect steps with all the bells and whistles. It has the same syntax as defn. If the first argument is not "game" it errors. 
 
@@ -97,10 +127,5 @@ defeffect-triggers: same as def-effect-full but disables stuff other than trigge
 
 defeffect: disables all the fancy stuff, useful for random timing structure steps or not really game actions that we still want to treat as one like writing to the log.
 
------------
-
 let-step macro: This macro gives you access to the results of a step. A step can use set-result to give a result, which can then be bound to a symbol with the let-step macro.
 Internally this works via set-result just putting the value in :step-result in game. The let-step macro will first recursively deconstruct itself into let-steps with a single binding each. Then it queues a step that just calls (set-result nil), then queues the given bindings value, then queues something that takes the :step-result from game and puts it in an atom. Then it will wrap its body in something that derefs the atom and binds the right symbol.  
-
------------
-

--- a/docs/draft_docs.txt
+++ b/docs/draft_docs.txt
@@ -4,7 +4,7 @@ Note that "changing the game state" does not include adding things to the queue 
 
 Effect Step: Basic indivisible units of game state change. Things like drawing cards, gaining credits or the steps of a timing structure fall into this.  
 Blocking Step: A step that causes the engine to stop what it's doing and wait for something. Usually it'll be waiting on a user because of a prompt. 
-Guard Step: A step that is aborted to by the abort step (which is an effect step). Any effect type can be used for this purpose. 
+Guard Step: A step that is aborted to by the abort step (which is an effect step). Any step type can be used for this purpose. 
 Composite Step: All other steps. These steps never do anything other than add steps (including effect steps) to the queue, potentially after examining the game state. simple-step gives composite steps.
 Composite Call: A composite step that can be used directly, in addition to queuing it. Composite calls should not depend on game state. Note that the distinction between a composition step and a composite call is in how the revelant function is defined not in how it is used. 
 
@@ -12,7 +12,7 @@ Prompt Step: A blocking step. Displays a custom prompt to the user.
 PAW Step: A blocking step. Represents a paid ability window. 
 Action Step: A blocking step. Represents the action phase ability window. 
 
-Interrupt Check Step: A composite step. Represents an interrupt window. 
+Interrupt Check Step: A composite step. Represents an interrupt window. Note it's composite even though it can block and change the game state, because it uses other prompts and effects to do that.
 
 Checkpoint Step: An effect step. Must be requested manually when required by the engine or cards. Acts as a blocking step for the purposes of the imminent instruction. 
 Imminent Instruction: The series of steps between the start of the pipeline and the next blocking step or checkpoint step. 
@@ -20,10 +20,10 @@ Expected Effects: The results of a process via which the interrupt system determ
 
 -----------
 
-pipeline Workings:
+Pipeline Workings:
 The pipeline runs with a simple (swap! @game handle-prompt-clicked player action). handle-prompt-clicked will give the action to the prompt at the beginning of the pipeline then call continue-game.
 
-On each invocation after than the first, the kernel expects to be given the action (e.g. prompt click) that caused the invocation. This action is passed to the prompt-clicked method of the first step in the queue prior to the main iteration being performed.
+On each invocation after the first, the kernel expects to be given the action (e.g. prompt click) that caused the invocation. This action is passed to the prompt-clicked method of the first step in the queue prior to the main iteration being performed.
 
 Each iteration of continue-game performs the following steps:
 Call update-pipeline.
@@ -41,80 +41,66 @@ Example:
 
 (defn example-composite-call [game some args whatever] (-> game (other-step some args) (more-step whatever)))
 
-If a function examines the game state or recurs, it's known as a composite step and must be defined as a proper step. Like with altering the game state examining the game state is something you must do directly to qualify. A function that draws cards until your hand is full would count because it looks at how many cards you have in hand (i.e. a value that could be altered if there are draw steps in the pipeline). As such this function should be defined as one that queues a step. The effect of the card game day would not count and can be implemented as a simple function, because it can just call that function.
+If a function examines the game state or recurs, it's known as a composite step and must be defined as a proper step. Like with altering the game state examining the game state is something you must do directly to qualify. A function that draws cards until your hand is full would count because it looks at how many cards you have in hand (i.e. a value that could be altered if there are draw steps in the pipeline). As such this function should be defined as one that queues a step (e.g. via defstep). The effect of the card Game Day would not count and can be implemented as a simple function, because it can just call that function. Likewise, the majority of cards can be implemented as simple functions. 
 
-Composite steps that wish to recur must be defined as a proper step and should use (queue-step this) to achieve this. A defn like macro is provided that makes any function a step or the as-step macro provides inline steps. For instance, this function can be safely defined with a simple defn:
+Composite steps that wish to recur must be defined as a proper step and should use (queue-step this) to achieve this. A defn like macro defstep is provided that makes any function a step or the as-step macro provides inline steps. For instance, this function can be safely defined with a simple defn:
 
-(defn simple-call [game] (-> game (blah) (blah) (blah) (as-step (step game (examine-state game))) (blah) (blah) (blah)))
-
+(defn simple-call [game] (-> game (blah) (blah) (blah) (as-step (some-effect game (examine-state game))) (blah) (blah) (blah)))
 
 Or showing recursion over a prompt:
 
-(-> game (blah) (blah)
-  (as-step (if (mu-limit-exceeded game)
-			   (-> game
-				   (trash-program-prompt)
-				   (queue-step this))
-			   game))
-  (blah) (blah) (blah))
+(defstep check-mu-usage [game]
+  (if (mu-limit-exceeded game)
+      (-> game
+          (trash-program-prompt)
+          (queue-step this))
+      game))
 
-
-As you can see if other-step and more-step were composite calls themselves with similar definitions they'd just immediately have their effect. This is safe because composite steps can only change the pipeline. They have no way to cause triggers or prompts. This means that composite steps are usually expanded before they ever hit the queue. Some composite steps must be true steps, mostly to allow the ablity to (queue-step this) and recur. This method of recursion is the main looping mechanism for the game. 
-
-The signature of the functions used is the same in either case, as with all steps. That same composite call as a true step is instead defined (probably via a macro) like so:
-
-(defn example-composite-step [game some args whatever] (-> game (queue-simple-step (other-step some args) (more-step whatever))))
-
-Either way the process for using them is the same as with all steps. Just thread game through the function. 
 
 Prompt Steps:
-Prompts can have any structure really, so long as the users click can be mapped to a step we're good. Prompt steps, like all steps, should define at least one function that you can thread game through and get them added to the queue. Prompts are thing most likely to want to define more functions for different cases. Most stuff should be able to use pretty simple versions though. 
+Prompts can have any structure really, so long as the users click can be mapped to a step we're good. Prompt steps, like all steps, should have at least one helper function that you can thread game through and get them added to the queue. Prompts are the thing most likely to want to define more functions for different cases. Most stuff should be able to use pretty simple versions though. 
 
 PAW Step:
 A prompt step that displays a pass button and activates relevant paid abilities/rezzing etc. 
 
 Action Step:
-Similar to the PAW step but displays the basic action card.
+Similar to the PAW step but displays the basic action card. 
 
 Interrupt Check Step:
 A composite step for interrupts. Interrupts are probably the most complicated part of the rules and consequently the engine.
-This step is not usually manually used by card or engine effects. Instead, as detailed below, it is used as part of resolving a step made with the def-effect-full macro.
+This step is not usually manually used by card or engine effects. Instead, as detailed below, it is used as part of resolving a step made with the defeffect macro.
 
 First, we calculate the expected effects of the imminent instruction. 
-This is done by setting the :expected key in game to an empty list and then calling continue-game. 
+This is done by setting the :expected-effects key in game to an empty list and then calling continue-game. 
 The presence of :expected causes checkpoints to become blocking and effect steps to append themselves to the :expected list when they run. 
 #I don't think there's an official ruling on if the effect steps should still be changing the state as well. It's utterly moot I think. It's no skin either way for us though.
-After extracting the :expected list from the returned game state the rest is discarded. 
+After extracting the :expected-effects list from the returned game state the rest is discarded. 
 
 The :expected list is checked against each active interrupt ability for relevance. If none are found, the check is over, disable interrupts (they will be enabled again at the next checkpoint). 
-If some are found, do a stanrd set of prompts/PAW to resolve them, disable interrupts and continue.
+If some are found, do a standard set of trigger prompts/PAW steps to resolve them, disable interrupts and continue.
 
-def-effect-full macro:
+defeffect-full macro:
 This macro is used to declare effect steps with all the bells and whistles. It has the same syntax as defn. If the first argument is not "game" it errors. 
 
-Using defstep will define a new step record/schema with a name created from the function name. So draw will produce DrawStep. 
+An entry will be created in the triggers, interrupts and prevention lists based on the function name. So draw will produce :runner-draw, :corp-draw and :draw in all lists. Modifiers can change these names or suppress some of this behaviour. 
 
-This record will have extra properties with names that correspond to the arguments of the function, excepting game of course. 
+A new function will be defined with the function name and arguments as given. This function simply creates a new instance of EffectStep with appropriate properties, including trigger names and the arguments to the function call, and queues it. 
 
-An entry will be created in the triggers and interrupts lists based on the function name. So draw will produce :runner-draw and :corp-draw in both lists. Modifiers can change these names or suppress some or all of this behaviour. The names are stored in properties of the record. 
+When the continue-step of this new step is called it will first check if there's an applicable prevention effect, and simply return if so.
+Then it will check if interrupts are disabled. If they are not it will queue an interrupt check step, then queue itself then return. 
 
-A new function will be defined with the function name and arguments as given. This function will check for relevant prevention effects, if none are found create a new instance of the step, setting the extra properties appropriately to its arguments and queue it. 
+If interrupts are disabled, execute the function body, passing in the arguments that were stored in EffectStep when it was created.
 
-When the continue-step of this new step is called it will first check if interrupts are disabled.
-If they are not it will queue an interrupt check step, then itself then return. 
+Then do a trigger check, adding relevant triggers to the trigger queue (not to be confused with the main queue). 
 
-After the interrupt check, execute the function body, passing in the arguments from the properties.
+defeffect-triggers: same as def-effect-full but disables stuff other than triggers, useful for start of turn or similar.
 
-Then do a trigger check in line with the interrupt check, but you just add relevant triggers to the trigger queue (not to be confused with the main queue). 
-
-def-effect-triggers: same as def-effect-full but disables stuff other than triggers, useful for start of turn or similar.
-
-def-effect-light: disables all the fancy stuff, useful for random timing structure steps or not really game actions like writing to the log
+defeffect: disables all the fancy stuff, useful for random timing structure steps or not really game actions that we still want to treat as one like writing to the log.
 
 -----------
 
-let-step macro: This macro gives you access to the results of a step. A step can use (set-result game result) to give a result, which can then be bound to a symbol with the let-step macro.
-Internally this works via set-result just putting the value in :return-value in game. The let-step macro will first handle its bindings. For each one it queues a step that just calls (set-result nil), then queues the given binding, then queues something that takes the :return-value from game and puts it in an atom. Then it will wrap its body in something that derefs the atoms and binds them to the right symbols.  
+let-step macro: This macro gives you access to the results of a step. A step can use set-result to give a result, which can then be bound to a symbol with the let-step macro.
+Internally this works via set-result just putting the value in :step-result in game. The let-step macro will first recursively deconstruct itself into let-steps with a single binding each. Then it queues a step that just calls (set-result nil), then queues the given bindings value, then queues something that takes the :step-result from game and puts it in an atom. Then it will wrap its body in something that derefs the atom and binds the right symbol.  
 
 -----------
 

--- a/docs/draft_docs.txt
+++ b/docs/draft_docs.txt
@@ -1,0 +1,109 @@
+Terminology:
+
+Note that "changing the game state" does not include adding things to the queue or otherwise manipulating the internal state of the engine. It means in game state.
+
+Effect Step: Basic indivisible units of game state change. Things like drawing cards, gaining credits or the steps of a timing structure fall into this. No other steps may change the game state. 
+Blocking Step: A step that causes the engine to stop what it's doing and wait for something. Usually it'll be waiting on a user because of a prompt. 
+Guard Step: A step that does nothing in itself but that can be aborted to by a special effect step. Each guard step has a keyword type associated with it. 
+Composite Step: All other steps. These steps never do anything other than add steps to the queue, potentially after examining the game state. simple-step gives composite steps.
+Composite Call: A composite step that can be used directly, in addition to queuing it. Composite calls should not depend on game state. Note that the distinction between a composition step and a composite call is in how the revelant function is defined not in how it is used. 
+
+Prompt Step: A blocking step. Displays a custom prompt to the user. 
+PAW Step: A blocking step. Represents a paid ability window. 
+Action Step: A blocking step. Represents the action phase ability window. 
+
+Interrupt Check Step: A composite step. Represents an interrupt window. 
+
+Checkpoint Step: An effect step. Must be requested manually when required by the engine or cards. Acts as a blocking step for the purposes of the pending instruction.
+Imminent Instruction: The series of steps between the start of the pipeline and the next blocking step or checkpoint step. 
+Expected Effects: The results of a process via which the interrupt system determines which effect steps will run before the next checkpoint.
+
+#I think this is the best way to handle checkpoints and pending instructions.
+
+Pipeline: The pipeline system itself. It just knows how to click prompts, build diffs and run steps.
+Core: The suite supporting functions/macros that allow you to manipulate the pipeline easily. 
+Engine: The game rules. Timing steps, effects and functions for examining the state.
+Cards: The cards.
+
+-----------
+
+pipeline Workings:
+The pipeline runs with a simple (swap! @game handle-prompt-clicked action). handle-prompt-clicked will give the action to the prompt at the beginning of the pipeline then call continue-game.
+
+Each invocation other than the first, the kernel expects to be given the action (e.g. prompt click) that caused the invocation. This action is passed to the prompt-clicked method of the first step in the queue prior to the main iteration being performed.
+
+Each iteration of continue-game performs the following steps:
+Call update-game.
+Call the blocking method of the next step in the queue. If it returns false, continue to the next step, otherwise return whatever the blocking method returned, which should be the game state inc prompt.
+If it returned false, update the game using the continue-step method of the next step and go to the next iteration. 
+
+--------
+
+Engine Workings:
+The majority of engine functions will either be game state reporting functions, which will be hopefully mostly unchanged, or composite steps/calls.
+
+Composite calls mostly follow the form (-> game (step) (step) (step)) and can be defined with a simple defn. They are the simplest and lightest of "steps" in that they needn't be backed by a step record or enter the pipeline at all. Though often they are, which is called a composite step. 
+
+Example:
+
+(defn example-composite-call [game some args whatever] (-> game (other-step some args) (more-step whatever)))
+
+As you can see if other-step and more-step were composite calls themselves with similar definitions they'd just immediately have their effect. This is safe because composite steps can only change the pipeline. They have no way to cause triggers or prompts. This means that composite steps are usually expanded before they ever hit the queue. Some composite steps must be true steps, mostly to allow the ablity to (queue-step this) and recur. This method of recursion is the main looping mechanism for the game. 
+
+The signature of the functions used is the same in either case, as with all steps. That same composite call as a true step is instead defined (probably via a macro) like so:
+
+(defn example-composite-step [game some args whatever] (-> game (queue-simple-step (other-step some args) (more-step whatever))))
+
+Either way the process for using them is the same as with all steps. Just thread game through the function. 
+
+Prompt Steps:
+Prompts can have any structure really, so long as the users click can be mapped to a step we're good. Prompt steps, like all steps, should define at least one function that you can thread game through and get them added to the queue. Prompts are thing most likely to want to define more functions for different cases. Most stuff should be able to use pretty simple versions though. 
+
+PAW Step:
+A prompt step that displays a pass button and activates relevant paid abilities/rezzing etc. 
+
+Action Step:
+Similar to the PAW step but displays the basic action card.
+
+Interrupt Check Step:
+A composite step for interrupts. Interrupts are probably the most complicated part of the rules and consequently the engine.
+This step is not usually manually used by card or engine effects. Instead, as detailed below, it is used as part of resolving a step made with the def-effect-full macro.
+
+First, we calculate the expected effects of the imminent instruction. 
+This is done by setting the :expected key in game to an empty list and then calling continue-game. 
+The presence of :expected causes checkpoints to become blocking and effect steps to append themselves to the :expected list when they run. 
+#I don't think there's an official ruling on if the effect steps should still be changing the state as well. It's utterly moot I think. It's no skin either way for us though.
+After extracting the :expected list from the returned game state the rest is discarded. 
+
+The :expected list is checked against each active interrupt ability for relevance. If none are found, the check is over, disable interrupts (they will be enabled again at the next checkpoint). 
+If some are found, do a stanrd set of prompts/PAW to resolve them, disable interrupts and continue.
+
+def-effect-full macro:
+This macro is used to declare effect steps with all the bells and whistles. It has the same syntax as defn. If the first argument is not "game" it errors. 
+
+Using defstep will define a new step record/schema with a name created from the function name. So draw will produce DrawStep. 
+
+This record will have extra properties with names that correspond to the arguments of the function, excepting game of course. 
+
+An entry will be created in the triggers and interrupts lists based on the function name. So draw will produce :runner-draw and :corp-draw in both lists. Modifiers can change these names or suppress some or all of this behaviour. The names are stored in properties of the record. 
+
+A new function will be defined with the function name and arguments as given. This function will check for relevant prevention effects, if none are found create a new instance of the step, setting the extra properties appropriately to its arguments and queue it. 
+
+When the continue-step of this new step is called it will first check if interrupts are disabled.
+If they are not it will queue an interrupt check step, then itself then return. 
+
+After the interrupt check, execute the function body, passing in the arguments from the properties.
+
+Then do a trigger check in line with the interrupt check, but you just add relevant triggers to the trigger queue (not to be confused with the main queue). 
+
+def-effect-triggers: same as def-effect-full but disables stuff other than triggers, useful for start of turn or similar.
+
+def-effect-light: disables all the fancy stuff, useful for random timing structure steps or not really game actions like writing to the log
+
+-----------
+
+let-step macro: This macro gives you access to the results of a step. A step can use (set-result game result) to give a result, which can then be bound to a symbol with the let-step macro.
+Internally this works via set-result just putting the value in :return-value in game. The let-step macro will first handle its bindings. For each one it queues a step that just calls (set-result nil), then queues the given binding, then queues something that takes the :return-value from game and puts it in an atom. Then it will wrap its body in something that derefs the atoms and binds them to the right symbols.  
+
+-----------
+

--- a/src/engine/draw.clj
+++ b/src/engine/draw.clj
@@ -1,5 +1,5 @@
 (ns engine.draw
-  (:require [engine.macros :refer [defeffect-full]]))
+  (:require [engine.steps.effect :refer [defeffect-full]]))
 
 (defeffect-full draw
   [game player amount]

--- a/src/engine/draw.clj
+++ b/src/engine/draw.clj
@@ -1,6 +1,7 @@
-(ns engine.draw)
+(ns engine.draw
+  (:require [engine.macros :refer [defeffect-full]]))
 
-(defn draw
+(defeffect-full draw
   [game player amount]
   (let [[drawn deck] (split-at amount (get-in game [player :deck]))]
     (-> game

--- a/src/engine/draw.clj
+++ b/src/engine/draw.clj
@@ -1,9 +1,11 @@
 (ns engine.draw
-  (:require [engine.steps.effect :refer [defeffect-full]]))
+  (:require [engine.steps.effect :refer [defeffect-full]]
+            [engine.macros :refer [set-result]]))
 
 (defeffect-full draw
   [game player amount]
   (let [[drawn deck] (split-at amount (get-in game [player :deck]))]
     (-> game
         (update-in [player :hand] into drawn)
-        (assoc-in [player :deck] (into [] deck)))))
+        (assoc-in [player :deck] (into [] deck))
+        (set-result amount))))

--- a/src/engine/game.clj
+++ b/src/engine/game.clj
@@ -2,6 +2,7 @@
   (:require
    [engine.pipeline :as pipeline]
    [engine.player :as player]
+   [engine.macros :refer [queue-simple-step]]
    [engine.steps.step :as step]
    [engine.steps.setup-phase :as setup-phase]
    [engine.steps.draw-phase :as draw-phase]
@@ -18,16 +19,13 @@
    :messages []
    :turns 0})
 
-(defn begin-turn []
-  (step/simple-step
-    (fn [game]
-      (-> game
-          (pipeline/queue-step (sot-phase/start-of-turn-phase))
-          (pipeline/queue-step (draw-phase/draw-phase))))))
+(defn begin-turn [game]
+  (-> game (sot-phase/start-of-turn-phase)
+           (draw-phase/draw-phase)))
 
 (defn start-new-game
   [opts]
   (-> (new-game opts)
-      (pipeline/queue-step (setup-phase/setup-phase))
-      (pipeline/queue-step (begin-turn))
+      (setup-phase/setup-phase)
+      (begin-turn)
       (pipeline/continue-game)))

--- a/src/engine/game.clj
+++ b/src/engine/game.clj
@@ -2,7 +2,6 @@
   (:require
    [engine.pipeline :as pipeline]
    [engine.player :as player]
-   [engine.macros :refer [queue-simple-step]]
    [engine.steps.step :as step]
    [engine.steps.setup-phase :as setup-phase]
    [engine.steps.draw-phase :as draw-phase]

--- a/src/engine/macros.clj
+++ b/src/engine/macros.clj
@@ -28,7 +28,7 @@
             bind-val (second bindings)]
         `(let [~'__result-atom__ (atom nil)
                ~'game (set-result ~game nil) ;Make sure we get nil if the step doesn't set anything.
-               ~'game ~bind-val
+               ~'game (as-step ~'game ~bind-val) ;The as-step isn't strictly necessary but allows safely examining state from bind values
                ~'game (as-step ~'game (reset! ~'__result-atom__ (get-in ~'game [:step-result])) ~'game)]
            (as-step ~'game (let [~bind-var (deref ~'__result-atom__)]
                       ~@body))))))

--- a/src/engine/macros.clj
+++ b/src/engine/macros.clj
@@ -1,0 +1,51 @@
+(ns engine.macros 
+  (:require [engine.steps.step :as step]
+            [engine.pipeline :as pipeline]))
+  
+;TODO move this into a sensible file and actually make it work and stuff
+(defn check-effect-prevention [game effect]
+	false)
+  
+(defn build-step-name [fname]
+  (symbol (str (clojure.string/capitalize fname) "Step")))
+  
+(defn build-keyword [fname]
+  [(keyword (str "effect-" fname))])
+
+(defn build-effect-body [func-name [game & args] & body]
+  body)
+
+(defn build-effect-record [func-name [game & args] & body]
+  (let [step-name (build-step-name func-name)]
+    `(defrecord ~step-name ~(into [] (conj args 'uuid))
+        step/Step
+        ~(concat '(continue-step [this game])
+          `(~(concat `(let ~(into [] (reduce concat (map #(identity [% `(~(keyword %) ~'this)]) args))))
+                  (apply build-effect-body (concat [func-name (concat [game] args)] body)))))
+        (~'blocking [~'_ ~'__] false) ; We never halt execution.
+        (~'on-prompt-clicked [~'this ~'game ~'player ~'arg] );TODO throw an error here, should never happen
+        (~'validate [~'this] ))))
+        
+(defn build-effect-function [func-name [game & args] & body]
+  (let [step-name (build-step-name func-name)
+        effect-keyword (build-keyword func-name)]
+  `(defn ~func-name ~(into [] (concat [game] args))
+     (if (check-effect-prevention ~game ~effect-keyword)
+       ~game
+       (pipeline/queue-step ~game (->> ~(into `{:type ~(str ":step/" func-name)
+                                                :uuid (java.util.UUID/randomUUID)}
+                                              (map #(identity [ (keyword %) %]) args))
+                                       (~(symbol (str "map->" step-name)))))))))
+
+;TODO error if no game argument, plus a ton of functionality
+(defmacro defeffect-full 
+  [func-name [game & args] & body]
+  (list 'do (apply build-effect-record (concat [func-name (concat [game] args)] body))
+        (apply build-effect-function (concat [func-name (concat [game] args)] body))))
+
+;Note that this is defined as a macro because its main utility is to provide access to (queue-step this).
+(defmacro queue-simple-step 
+  [game & body]
+    `(pipeline/queue-step ~game (step/make-base-step {:continue-step 
+       ~(concat '(fn [this game])
+              body)})))

--- a/src/engine/macros.clj
+++ b/src/engine/macros.clj
@@ -1,15 +1,34 @@
-(ns engine.macros 
+(ns engine.macros
   (:require [engine.steps.step :as step]
             [engine.pipeline :as pipeline]))
-  
+
 
 (defmacro as-step
   [game & body]
-    `(pipeline/queue-step ~game (step/make-base-step {:continue-step 
-       ~(concat '(fn [this game])
-              body)})))
+    `(pipeline/queue-step ~game (step/make-base-step {:continue-step
+       (fn [~'this ~'game] ~@body)})))
 
 (defmacro defstep
   [func-name & code]
   (let [[args & body] (if (string? (first code)) (rest code) code)];Trim docstrings to mimic defn, really we want to use a library like defntly to handle all this correctly
-    `(defn ~func-name ~args ~(concat `(engine.macros/as-step ~(first args)) body))))
+    `(defn ~func-name ~args (engine.macros/as-step ~(first args) ~@body))))
+
+
+(defstep set-result
+  [game result]
+  (assoc-in game [:step-result] result))
+
+(defmacro let-step
+  [game bindings & body]
+  (if (< 2 (count bindings));If there's more than 1 var being bound split off the first and recur
+      (let [cur-bind (into [] (take 2 bindings))
+            others (into [] (drop 2 bindings))]
+        `(let-step ~game ~cur-bind (let-step ~'game ~others ~@body)))
+      (let [bind-var (first bindings)
+            bind-val (second bindings)]
+        `(let [~'__result-atom__ (atom nil)
+               ~'game (set-result ~game nil) ;Make sure we get nil if the step doesn't set anything.
+               ~'game ~bind-val
+               ~'game (as-step ~'game (reset! ~'__result-atom__ (get-in ~'game [:step-result])) ~'game)]
+           (as-step ~'game (let [~bind-var (deref ~'__result-atom__)]
+                      ~@body))))))

--- a/src/engine/macros.clj
+++ b/src/engine/macros.clj
@@ -2,50 +2,14 @@
   (:require [engine.steps.step :as step]
             [engine.pipeline :as pipeline]))
   
-;TODO move this into a sensible file and actually make it work and stuff
-(defn check-effect-prevention [game effect]
-	false)
-  
-(defn build-step-name [fname]
-  (symbol (str (clojure.string/capitalize fname) "Step")))
-  
-(defn build-keyword [fname]
-  [(keyword (str "effect-" fname))])
 
-(defn build-effect-body [func-name [game & args] & body]
-  body)
-
-(defn build-effect-record [func-name [game & args] & body]
-  (let [step-name (build-step-name func-name)]
-    `(defrecord ~step-name ~(into [] (conj args 'uuid))
-        step/Step
-        ~(concat '(continue-step [this game])
-          `(~(concat `(let ~(into [] (reduce concat (map #(identity [% `(~(keyword %) ~'this)]) args))))
-                  (apply build-effect-body (concat [func-name (concat [game] args)] body)))))
-        (~'blocking [~'_ ~'__] false) ; We never halt execution.
-        (~'on-prompt-clicked [~'this ~'game ~'player ~'arg] );TODO throw an error here, should never happen
-        (~'validate [~'this] ))))
-        
-(defn build-effect-function [func-name [game & args] & body]
-  (let [step-name (build-step-name func-name)
-        effect-keyword (build-keyword func-name)]
-  `(defn ~func-name ~(into [] (concat [game] args))
-     (if (check-effect-prevention ~game ~effect-keyword)
-       ~game
-       (pipeline/queue-step ~game (->> ~(into `{:type ~(str ":step/" func-name)
-                                                :uuid (java.util.UUID/randomUUID)}
-                                              (map #(identity [ (keyword %) %]) args))
-                                       (~(symbol (str "map->" step-name)))))))))
-
-;TODO error if no game argument, plus a ton of functionality
-(defmacro defeffect-full 
-  [func-name [game & args] & body]
-  (list 'do (apply build-effect-record (concat [func-name (concat [game] args)] body))
-        (apply build-effect-function (concat [func-name (concat [game] args)] body))))
-
-;Note that this is defined as a macro because its main utility is to provide access to (queue-step this).
-(defmacro queue-simple-step 
+(defmacro as-step
   [game & body]
     `(pipeline/queue-step ~game (step/make-base-step {:continue-step 
        ~(concat '(fn [this game])
               body)})))
+
+(defmacro defstep
+  [func-name & code]
+  (let [[args & body] (if (string? (first code)) (rest code) code)];Trim docstrings to mimic defn, really we want to use a library like defntly to handle all this correctly
+    `(defn ~func-name ~args ~(concat `(engine.macros/as-step ~(first args)) body))))

--- a/src/engine/messages.clj
+++ b/src/engine/messages.clj
@@ -1,6 +1,7 @@
 (ns engine.messages
   (:require
-    [clojure.string :as str]))
+    [clojure.string :as str]
+    [engine.macros :refer [as-step]]))
 
 (defn strip-for-message
   [obj]
@@ -27,5 +28,5 @@
 (defn add-message
   ([game message] (add-message game message nil))
   ([game message args]
-   (update game :messages conj {:date (java.util.Date.)
-                                :text (format-message message args)})))
+   (as-step game (update game :messages conj {:date (java.util.Date.)
+                                              :text (format-message message args)}))))

--- a/src/engine/pipeline.clj
+++ b/src/engine/pipeline.clj
@@ -29,7 +29,10 @@
     (if-let [step (get-current-step game)]
       (if-let [prompt-game (step/blocking step game)]
         prompt-game
-        (let [new-game (step/continue-step step game)]
+        (let [new-game (try (step/continue-step step game)
+                            (catch Exception e
+                                   (clojure.pprint/pprint game) ;Todo setup exinfo
+                                   (throw e)))]
           (recur (drop-current-step new-game))))
       game)));This should probably be an error, empty pipeline shouldn't happen
 

--- a/src/engine/pipeline.clj
+++ b/src/engine/pipeline.clj
@@ -12,10 +12,6 @@
   [game]
   (get-in game [:gp :pipeline 0]))
 
-(defn complete-current-step
-  [game]
-  (assoc-in game [:gp :pipeline 0 :complete?] true))
-
 (defn drop-current-step
   [game]
   (specter/setval [:gp :pipeline specter/FIRST] specter/NONE game))
@@ -31,14 +27,17 @@
   [game]
   (let [game (update-pipeline game)]
     (if-let [step (get-current-step game)]
-      (let [[result new-game] (step/continue-step step game)]
-        (if result
-          (recur (drop-current-step new-game))
-          [false new-game]))
-      [true game])))
+      (if-let [prompt-game (step/blocking step game)]
+        prompt-game
+        (let [new-game (step/continue-step step game)]
+          (recur (drop-current-step new-game))))
+      game)));This should probably be an error, empty pipeline shouldn't happen
 
 (defn handle-prompt-clicked
   [game player button]
   (if-let [step (get-current-step game)]
-    (step/on-prompt-clicked step game player button)
-    [false game]))
+    (let [step (step/on-prompt-clicked step game player button)]
+      (-> game (drop-current-step)
+               (queue-step step)
+               (continue-game)))
+    game))

--- a/src/engine/player.clj
+++ b/src/engine/player.clj
@@ -3,7 +3,7 @@
     [engine.prompt-state :as prompt-state]))
 
 (defn new-player
-  [{:keys [user identity deck]}]
+  [{:keys [user identity deck credits]}]
   {:deck-list (or deck [])
    :deck (or deck [])
    :discard []
@@ -14,7 +14,7 @@
    :rfg []
    :scored []
    :set-aside []
-   :credits 0
+   :credits (or credits 5)
    :clicks 0
    :agenda-points 0
    :name (:username user)})

--- a/src/engine/steps/action_phase.clj
+++ b/src/engine/steps/action_phase.clj
@@ -2,7 +2,6 @@
   (:require
    [engine.messages :as msg]
    [engine.pipeline :as pipeline :refer [queue-step]]
-   [engine.macros :refer [queue-simple-step]]
    [engine.steps.prompt :as prompt]))
 
 (defn action-active-prompt

--- a/src/engine/steps/action_phase.clj
+++ b/src/engine/steps/action_phase.clj
@@ -17,8 +17,7 @@
     (update-in game [player :credits] inc)))
 
 (defn action-phase [game player]
-  (queue-step game 
-    (prompt/base-prompt
-      {:active-condition player
-       :active-prompt action-active-prompt
-       :on-prompt-clicked action-prompt-clicked})))
+  (prompt/base-prompt game
+    {:active-condition player
+     :active-prompt action-active-prompt
+     :on-prompt-clicked action-prompt-clicked}))

--- a/src/engine/steps/action_phase.clj
+++ b/src/engine/steps/action_phase.clj
@@ -1,7 +1,8 @@
 (ns engine.steps.action-phase
   (:require
    [engine.messages :as msg]
-   [engine.pipeline :as pipeline]
+   [engine.pipeline :as pipeline :refer [queue-step]]
+   [engine.macros :refer [queue-simple-step]]
    [engine.steps.prompt :as prompt]))
 
 (defn action-active-prompt
@@ -13,12 +14,12 @@
 (defn action-prompt-clicked
   [_this game player _arg]
   (let [game (-> game
-                 (pipeline/complete-current-step)
                  (msg/add-message "{0} gains 1 credit." [(get game player)]))]
-    [true (update-in game [player :credits] inc)]))
+    (update-in game [player :credits] inc)))
 
-(defn action-phase [player]
-  (prompt/base-prompt
-    {:active-condition player
-     :active-prompt action-active-prompt
-     :on-prompt-clicked action-prompt-clicked}))
+(defn action-phase [game player]
+  (queue-step game 
+    (prompt/base-prompt
+      {:active-condition player
+       :active-prompt action-active-prompt
+       :on-prompt-clicked action-prompt-clicked})))

--- a/src/engine/steps/draw_phase.clj
+++ b/src/engine/steps/draw_phase.clj
@@ -3,19 +3,16 @@
    [engine.draw :as draw]
    [engine.messages :as msg]
    [engine.steps.phase :as phase]
-   [engine.pipeline :refer [queue-step]]
-   [engine.macros :refer [queue-simple-step]]))
+   [engine.macros :refer [defstep]]))
 
-(defn mandatory-draw [game]
-  (queue-simple-step game
-      (-> game
-          (msg/add-message "{0} draws 1 card for their mandatory draw." [(:corp game)])
-          (draw/draw :corp 1))))
+(defstep mandatory-draw [game]
+  (-> game
+      (msg/add-message "{0} draws 1 card for their mandatory draw." [(:corp game)])
+      (draw/draw :corp 1)))
 
-(defn draw-phase [game]
-  (queue-simple-step game
-    (if (= :corp (:active-player game))
-        (phase/phase-step game
-          {:phase :draw
-           :steps [mandatory-draw]})
-        game)))
+(defstep draw-phase [game]
+  (if (= :corp (:active-player game))
+      (phase/phase game
+        {:phase :draw
+         :steps mandatory-draw})
+      game))

--- a/src/engine/steps/draw_phase.clj
+++ b/src/engine/steps/draw_phase.clj
@@ -3,17 +3,19 @@
    [engine.draw :as draw]
    [engine.messages :as msg]
    [engine.steps.phase :as phase]
-   [engine.steps.step :as step :refer [simple-step]]))
+   [engine.pipeline :refer [queue-step]]
+   [engine.macros :refer [queue-simple-step]]))
 
-(defn mandatory-draw []
-  (simple-step
-    (fn [game]
+(defn mandatory-draw [game]
+  (queue-simple-step game
       (-> game
           (msg/add-message "{0} draws 1 card for their mandatory draw." [(:corp game)])
-          (draw/draw :corp 1)))))
+          (draw/draw :corp 1))))
 
-(defn draw-phase []
-  (phase/make-phase
-    {:phase :draw
-     :condition (fn [game] (= :corp (:active-player game)))
-     :steps [(mandatory-draw)]}))
+(defn draw-phase [game]
+  (queue-simple-step game
+    (if (= :corp (:active-player game))
+        (phase/phase-step game
+          {:phase :draw
+           :steps [mandatory-draw]})
+        game)))

--- a/src/engine/steps/draw_phase.clj
+++ b/src/engine/steps/draw_phase.clj
@@ -5,7 +5,7 @@
    [engine.steps.phase :as phase]
    [engine.macros :refer [defstep]]))
 
-(defstep mandatory-draw [game]
+(defn mandatory-draw [game]
   (-> game
       (msg/add-message "{0} draws 1 card for their mandatory draw." [(:corp game)])
       (draw/draw :corp 1)))

--- a/src/engine/steps/effect.clj
+++ b/src/engine/steps/effect.clj
@@ -1,4 +1,4 @@
-(ns engine.steps.effect 
+(ns engine.steps.effect
   (:require
    [engine.pipeline :refer [queue-step]]
    [engine.steps.step :as step]))
@@ -12,8 +12,8 @@
   (blocking [this game] false);Effect steps don't block
   (validate [this] false);TODO!
   (on-prompt-clicked [_this game _player _click] game);This should maybe throw, no prompts here
-  
-  (continue-step [this game] 
+
+  (continue-step [this game]
     ;TODO all the automatic stuff like triggers etc, the type field is the trigger keyword
     (if (check-effect-prevention game type values)
         game
@@ -29,10 +29,10 @@
        (queue-step game)))
 
 ;I'm only doing defeffect-full atm, lighter versions will be available
-(defmacro defeffect-full 
+(defmacro defeffect-full
   [effect-name args & body]
   (let [unsafe-name (symbol (str effect-name "-unsafe"))
-        type-name (keyword effect-name)] ;Maybe a suffix or prefix here. This is the keyword you use 
-    `(do ~(concat `(defn ~unsafe-name ~(into [] (concat ['this] args))) body) ;Define the function given, with -unsafe appended to its name and "this" prepended to its arguments
+        type-name (keyword effect-name)] ;Maybe a suffix or prefix here. This is the keyword you use for trigger etc
+    `(do (defn ~unsafe-name ~(into [] (concat ['this] args)) ~@body) ;Define the function given, with -unsafe appended to its name and "this" prepended to its arguments
          (defn ~effect-name [~'game & ~'values] ;Define a function with the given name that queues an appropriate effect step ;TODO preserve arity
            (queue-effect-step ~'game ~unsafe-name ~'values ~type-name)))))

--- a/src/engine/steps/effect.clj
+++ b/src/engine/steps/effect.clj
@@ -1,0 +1,38 @@
+(ns engine.steps.effect 
+  (:require
+   [engine.pipeline :refer [queue-step]]
+   [engine.steps.step :as step]))
+
+(defn check-effect-prevention [game type values]
+  false)
+
+(defrecord EffectStep
+  [uuid continue-step values type];I'm not sure if we should include player as a value all effects have?
+  step/Step
+  (blocking [this game] false);Effect steps don't block
+  (validate [this] false);TODO!
+  (on-prompt-clicked [_this game _player _click] game);This should maybe throw, no prompts here
+  
+  (continue-step [this game] 
+    ;TODO all the automatic stuff like triggers etc, the type field is the trigger keyword
+    (if (check-effect-prevention game type values)
+        game
+        (apply continue-step this game values))))
+
+
+;Do not call this directly, call the function named after the effect you want.
+(defn queue-effect-step [game continue-step values type]
+  (->> {:continue-step continue-step
+        :values values
+        :type type}
+       (map->EffectStep)
+       (queue-step game)))
+
+;I'm only doing defeffect-full atm, lighter versions will be available
+(defmacro defeffect-full 
+  [effect-name args & body]
+  (let [unsafe-name (symbol (str effect-name "-unsafe"))
+        type-name (keyword effect-name)] ;Maybe a suffix or prefix here. This is the keyword you use 
+    `(do ~(concat `(defn ~unsafe-name ~(into [] (concat ['this] args))) body) ;Define the function given, with -unsafe appended to its name and "this" prepended to its arguments
+         (defn ~effect-name [~'game & ~'values] ;Define a function with the given name that queues an appropriate effect step ;TODO preserve arity
+           (queue-effect-step ~'game ~unsafe-name ~'values ~type-name)))))

--- a/src/engine/steps/mulligan_step.clj
+++ b/src/engine/steps/mulligan_step.clj
@@ -29,7 +29,7 @@
                           (into []))]
         (-> game
           (assoc [player :deck] new-deck)
-          (draw/draw player 5))))))
+          (draw/draw-unsafe player 5))))))
 
 (defn mulligan-prompt [game player]
   (queue-step game (prompt/base-prompt

--- a/src/engine/steps/mulligan_step.clj
+++ b/src/engine/steps/mulligan_step.clj
@@ -32,7 +32,7 @@
           (draw/draw-unsafe player 5))))))
 
 (defn mulligan-prompt [game player]
-  (queue-step game (prompt/base-prompt
+  (prompt/base-prompt game
     {:active-condition player
      :active-prompt mulligan-active-prompt
-     :on-prompt-clicked mulligan-prompt-clicked})))
+     :on-prompt-clicked mulligan-prompt-clicked}))

--- a/src/engine/steps/phase.clj
+++ b/src/engine/steps/phase.clj
@@ -17,14 +17,16 @@
 (defn queue-phase-steps
   [game {:keys [phase steps]
          :or {phase :base steps identity}}]
-  (-> game (start-phase phase)
-           (steps)
-           (end-phase)))
+  (let [steps (if (sequential? steps) (apply comp (reverse steps)) steps)] ;allow for a list as well
+       (-> game (start-phase phase)
+                (steps)
+                (end-phase))))
 
 (def PhaseOptsSchema
   [:map {:closed true}
    [:phase {:optional true} :keyword]
-   [:steps {:optional true} [:=> [:cat :map] [:cat :map]]]])
+   [:steps {:optional true} [:or [:=> [:cat :map] :map]
+                                 [:sequential [:=> [:cat :map] :map]]]]])
 
 (def validate-opts (m/validator PhaseOptsSchema))
 (def explain-opts (m/explainer PhaseOptsSchema))

--- a/src/engine/steps/setup_phase.clj
+++ b/src/engine/steps/setup_phase.clj
@@ -1,30 +1,29 @@
 (ns engine.steps.setup-phase
   (:require
    [engine.draw :as draw]
-   [engine.steps.step :refer [simple-step]]
    [engine.steps.mulligan-step :as mulligan]
+   [engine.steps.phase :as phase]
+   [engine.pipeline :refer [queue-step]]
+   [engine.macros :refer [queue-simple-step]]
    [engine.steps.phase :as phase]))
 
-(defn setup-begin []
-  (simple-step
-    (fn [game]
-      (-> game
-          (assoc-in [:corp :credits] 5)
-          (assoc-in [:runner :credits] 5)))))
+(defn setup-begin [game]
+  (-> game (queue-simple-step
+             (-> game (assoc-in [:corp :credits] 5)
+                      (assoc-in [:runner :credits] 5)))))
 
-(defn draw-initial-hands []
-  (simple-step
-    (fn [game]
-      (-> game
-          (update-in [:corp :deck] shuffle)
-          (update-in [:runner :deck] shuffle)
-          (draw/draw :corp 5)
-          (draw/draw :runner 5)))))
+(defn draw-initial-hands [game]
+  (-> game
+      (update-in [:corp :deck] shuffle)
+      (update-in [:runner :deck] shuffle)
+      (draw/draw :corp 5)
+      (draw/draw :runner 5)))
 
-(defn setup-phase []
-  (phase/make-phase
+(defn setup-phase [game]
+  (phase/phase-step game
     {:phase :setup
-     :steps [(setup-begin)
-             (draw-initial-hands)
-             (mulligan/mulligan-prompt :corp)
-             (mulligan/mulligan-prompt :runner)]}))
+     :steps [setup-begin
+             draw-initial-hands
+             #(mulligan/mulligan-prompt % :corp)
+             #(mulligan/mulligan-prompt % :runner)]}))
+

--- a/src/engine/steps/setup_phase.clj
+++ b/src/engine/steps/setup_phase.clj
@@ -4,26 +4,22 @@
    [engine.steps.mulligan-step :as mulligan]
    [engine.steps.phase :as phase]
    [engine.pipeline :refer [queue-step]]
-   [engine.macros :refer [queue-simple-step]]
-   [engine.steps.phase :as phase]))
+   [engine.macros :refer [defstep as-step]]))
 
-(defn setup-begin [game]
-  (-> game (queue-simple-step
-             (-> game (assoc-in [:corp :credits] 5)
-                      (assoc-in [:runner :credits] 5)))))
-
-(defn draw-initial-hands [game]
+(defstep draw-initial-hands [game]
   (-> game
       (update-in [:corp :deck] shuffle)
       (update-in [:runner :deck] shuffle)
-      (draw/draw :corp 5)
-      (draw/draw :runner 5)))
+      (as-step (draw/draw-unsafe this game :corp 5)) ;Don't trigger effects due to this draw
+      ;The as-step isn't really necessary here as the game has hardly started, just showing off the safe way to avoid interrupts/triggers/prevention etc. 
+      ;In most cases it would be though, you're still changing the state and need to put your stuff in the pipeline.
+      ;Note that the function takes "this" as an argument allow effects to use (queue-step this) and be recursive if they wish, mostly for consistency. Effects probably shouldn't be doing that.
+      (as-step (draw/draw-unsafe this game :runner 5))))
 
 (defn setup-phase [game]
-  (phase/phase-step game
+  (phase/phase game
     {:phase :setup
-     :steps [setup-begin
-             draw-initial-hands
-             #(mulligan/mulligan-prompt % :corp)
-             #(mulligan/mulligan-prompt % :runner)]}))
+     :steps #(-> % (draw-initial-hands)
+                   (mulligan/mulligan-prompt :corp)
+                   (mulligan/mulligan-prompt :runner))}))
 

--- a/src/engine/steps/setup_phase.clj
+++ b/src/engine/steps/setup_phase.clj
@@ -11,9 +11,9 @@
       (update-in [:corp :deck] shuffle)
       (update-in [:runner :deck] shuffle)
       (as-step (draw/draw-unsafe this game :corp 5)) ;Don't trigger effects due to this draw
-      ;The as-step isn't really necessary here as the game has hardly started, just showing off the safe way to avoid interrupts/triggers/prevention etc. 
+      ;The as-step isn't really necessary here as the game has hardly started, just showing off the safe way to avoid interrupts/triggers/prevention etc.
       ;In most cases it would be though, you're still changing the state and need to put your stuff in the pipeline.
-      ;Note that the function takes "this" as an argument allow effects to use (queue-step this) and be recursive if they wish, mostly for consistency. Effects probably shouldn't be doing that.
+      ;Note that the function takes "this" as an argument allow effects to use (queue-step this) and be recursive if they wish, mostly for consistency.
       (as-step (draw/draw-unsafe this game :runner 5))))
 
 (defn setup-phase [game]
@@ -22,4 +22,3 @@
      :steps #(-> % (draw-initial-hands)
                    (mulligan/mulligan-prompt :corp)
                    (mulligan/mulligan-prompt :runner))}))
-

--- a/src/engine/steps/start_of_turn_phase.clj
+++ b/src/engine/steps/start_of_turn_phase.clj
@@ -1,34 +1,33 @@
 (ns engine.steps.start-of-turn-phase
   (:require
-   [engine.macros :refer [queue-simple-step]]
+   [engine.macros :refer [defstep]]
    [engine.pipeline :refer [queue-step]]
    [engine.steps.phase :as phase]))
 
-(defn gain-allotted-clicks [game]
-  (queue-simple-step game
-    (let [active-player (:active-player game)
-          default (get-in game [active-player :clicks-per-turn])]
-      (assoc-in game [active-player :clicks] default))))
+(defstep gain-allotted-clicks [game]
+  (let [active-player (:active-player game)
+        default (get-in game [active-player :clicks-per-turn])]
+    (assoc-in game [active-player :clicks] default)))
 
-(defn start-of-turn-paw
+(defstep start-of-turn-paw
   "Stub until PAWs are developed"
   [game]
-  (queue-simple-step game game))
+  game)
 
-(defn refill-recurring-credits
+(defstep refill-recurring-credits
   "Stub until recurring credits are developed"
   [game]
-  (queue-simple-step game game))
+  game)
 
-(defn trigger-start-of-turn-abilities
+(defstep trigger-start-of-turn-abilities
   "Stub until abilities and conditional abilities are developed"
   [game]
-  (queue-simple-step game game))
+  game)
 
-(defn checkpoint
+(defstep checkpoint
   "Stub until checkpoints are developed"
   [game]
-  (queue-simple-step game game))
+  game)
 
 (defn start-of-turn-phase
   "* click allotment
@@ -37,10 +36,10 @@
   * “when your turn begins”
   * checkpoint"
   [game]
-  (phase/phase-step game
+  (phase/phase game
     {:phase :start-of-turn
-     :steps [gain-allotted-clicks
-             start-of-turn-paw
-             refill-recurring-credits
-             trigger-start-of-turn-abilities
-             checkpoint]}))
+     :steps #(-> % (gain-allotted-clicks)
+                   (start-of-turn-paw)
+                   (refill-recurring-credits)
+                   (trigger-start-of-turn-abilities)
+                   (checkpoint))}))

--- a/src/engine/steps/start_of_turn_phase.clj
+++ b/src/engine/steps/start_of_turn_phase.clj
@@ -1,34 +1,34 @@
 (ns engine.steps.start-of-turn-phase
   (:require
-   [engine.steps.step :as step :refer [simple-step]]
+   [engine.macros :refer [queue-simple-step]]
+   [engine.pipeline :refer [queue-step]]
    [engine.steps.phase :as phase]))
 
-(defn gain-allotted-clicks []
-  (simple-step
-    (fn [game]
-      (let [active-player (:active-player game)
-            default (get-in game [active-player :clicks-per-turn])]
-        (assoc-in game [active-player :clicks] default)))))
+(defn gain-allotted-clicks [game]
+  (queue-simple-step game
+    (let [active-player (:active-player game)
+          default (get-in game [active-player :clicks-per-turn])]
+      (assoc-in game [active-player :clicks] default))))
 
 (defn start-of-turn-paw
   "Stub until PAWs are developed"
-  []
-  (simple-step (fn [game] game)))
+  [game]
+  (queue-simple-step game game))
 
 (defn refill-recurring-credits
   "Stub until recurring credits are developed"
-  []
-  (simple-step (fn [game] game)))
+  [game]
+  (queue-simple-step game game))
 
 (defn trigger-start-of-turn-abilities
   "Stub until abilities and conditional abilities are developed"
-  []
-  (simple-step (fn [game] game)))
+  [game]
+  (queue-simple-step game game))
 
 (defn checkpoint
   "Stub until checkpoints are developed"
-  []
-  (simple-step (fn [game] game)))
+  [game]
+  (queue-simple-step game game))
 
 (defn start-of-turn-phase
   "* click allotment
@@ -36,11 +36,11 @@
   * recurring credits
   * “when your turn begins”
   * checkpoint"
-  []
-  (phase/make-phase
+  [game]
+  (phase/phase-step game
     {:phase :start-of-turn
-     :steps [(gain-allotted-clicks)
-             (start-of-turn-paw)
-             (refill-recurring-credits)
-             (trigger-start-of-turn-abilities)
-             (checkpoint)]}))
+     :steps [gain-allotted-clicks
+             start-of-turn-paw
+             refill-recurring-credits
+             trigger-start-of-turn-abilities
+             checkpoint]}))

--- a/src/engine/steps/step.clj
+++ b/src/engine/steps/step.clj
@@ -8,7 +8,7 @@
   even if it takes other args (such as the game state), it should be listed here
   and implemented for all steps."
   (continue-step [this game] "Calls the :continue function on the step. Should provide wrapping functionality in the protocol implementation.")
-  (complete? [this] "Is the step complete?")
+  (blocking [this game] "Should this step stop the engine. If not, this should be false. If so, it should be the state that is sent to the user.")
   (validate [this] "Validation through an external malli schema.")
   ; (on-card-clicked [this game player card] "What should happen when a card is clicked.")
   (on-prompt-clicked [this game player arg] "What should happen when a button on a prompt is clicked."))
@@ -16,7 +16,7 @@
 (defn ^:private -continue-step
   [this]
   (throw (ex-info (str "Step <" this "> is not a valid step") {:step this})))
-(defn ^:private -complete?
+(defn ^:private -blocking
   [this]
   (throw (ex-info (str "Step <" this "> is not a valid step") {:step this})))
 (defn ^:private -validate
@@ -29,21 +29,21 @@
 (extend-protocol Step
   Object
   (continue-step [this _game] (-continue-step this))
-  (complete? [this] (-complete? this))
+  (blocking [this _game] (-blocking this))
   (validate [this] (-validate this))
-  (on-card-clicked [this _game _player _arg]
+  (on-prompt-clicked [this _game _player _arg]
     (-on-prompt-clicked this))
   nil
   (continue-step [this _game] (-continue-step this))
-  (complete? [this] (-complete? this))
+  (blocking [this _game] (-blocking this))
   (validate [this] (-validate this))
-  (on-card-clicked [this _game _player _arg]
+  (on-prompt-clicked [this _game _player _arg]
     (-on-prompt-clicked this)))
 
 (def BaseStepSchema
   [:map {:closed true}
    [:continue-step [:=> [:cat :any :map]
-                    [:cat :boolean :any]]]
+                    [:cat :any]]]
    [:type [:qualified-keyword {:namespace :step}]]
    [:uuid uuid?]])
 
@@ -54,8 +54,8 @@
   [continue-step type uuid]
   Step
   (continue-step [this state] (continue-step this state))
-  (complete? [_])
-  (on-prompt-clicked [_this game _player _arg] [false game])
+  (blocking [_ game] false) ;This returns false to continue processing, or a game state that will be sent to the client. It is called before continue-step.
+  (on-prompt-clicked [_this game _player _arg] game)
   (validate [this]
     (if (validate-base-step this)
       this
@@ -63,7 +63,7 @@
         (throw (ex-info (str "Base step isn't valid: " (pr-str (me/humanize explained-error)))
                         (select-keys explained-error [:errors])))))))
 
-(defn default-continue-step [_step game] [true game])
+(defn default-continue-step [_step game] game)
 
 (defn make-base-step
   ([] (make-base-step nil))
@@ -77,7 +77,7 @@
 (defn simple-step-wrapper
   [continue-step]
   (fn simple-step-wrapper [_ game]
-    [true (continue-step game)]))
+    (continue-step game)))
 
 (defn simple-step
   [continue-step]

--- a/src/engine/steps/step.clj
+++ b/src/engine/steps/step.clj
@@ -82,4 +82,3 @@
 (defn simple-step
   [continue-step]
   (make-base-step {:continue-step (simple-step-wrapper continue-step)}))
-

--- a/src/engine/steps/step.clj
+++ b/src/engine/steps/step.clj
@@ -43,7 +43,7 @@
 (def BaseStepSchema
   [:map {:closed true}
    [:continue-step [:=> [:cat :any :map]
-                    [:cat :any]]]
+                    [:cat :map]]]
    [:type [:qualified-keyword {:namespace :step}]]
    [:uuid uuid?]])
 
@@ -82,3 +82,4 @@
 (defn simple-step
   [continue-step]
   (make-base-step {:continue-step (simple-step-wrapper continue-step)}))
+

--- a/test/engine/game_test.clj
+++ b/test/engine/game_test.clj
@@ -18,7 +18,6 @@
 (deftest corp-turn-test
   (is (= 6 (-> (sut/start-new-game {:corp {:user {:username "Corp player"}
                                            :deck [:a :b :c :d :e :f :g :h :i :j]}})
-               (second)
                (click-prompt :corp "Keep")
                (click-prompt :runner "Keep")
                (get-in [:corp :hand])

--- a/test/engine/messages_test.clj
+++ b/test/engine/messages_test.clj
@@ -8,33 +8,27 @@
 (deftest chat-log-test
   (is (= [{:text ["Hello!"]}]
          (-> (game/start-new-game nil)
-             (second)
              (sut/add-message "Hello!")
              (get-messages))))
   (is (= [{:text ["Hello!"]}
           {:text ["Goodbye!"]}]
          (-> (game/start-new-game nil)
-             (second)
              (sut/add-message "Hello!")
              (sut/add-message "Goodbye!")
              (get-messages))))
   (is (thrown? java.lang.IndexOutOfBoundsException
                (-> (game/start-new-game nil)
-                   (second)
                    (sut/add-message "Hello {0}!"))))
   (is (= [{:text ["Hello" "Noah" "!"]}]
          (-> (game/start-new-game nil)
-             (second)
              (sut/add-message "Hello {0}!" ["Noah"])
              (get-messages))))
   (is (= [{:text ["Hello" {:name "Noah"} "!"]}]
          (-> (game/start-new-game nil)
-             (second)
              (sut/add-message "Hello {0}!" [{:name "Noah"
                                              :no-match "Bogart"}])
              (get-messages))))
   (is (= [{:text ["going" "," "going" "and" "gone" "!"]}]
          (-> (game/start-new-game nil)
-             (second)
              (sut/add-message "{0}, {0} and {1}!" ["going" "gone"])
              (get-messages)))))

--- a/test/engine/messages_test.clj
+++ b/test/engine/messages_test.clj
@@ -3,32 +3,39 @@
    [clojure.test :refer [deftest is]]
    [engine.game :as game]
    [engine.messages :as sut]
+   [engine.pipeline :refer [continue-game]]
    [engine.test-helper :refer [get-messages]]))
 
 (deftest chat-log-test
   (is (= [{:text ["Hello!"]}]
          (-> (game/start-new-game nil)
              (sut/add-message "Hello!")
+             (continue-game)
              (get-messages))))
   (is (= [{:text ["Hello!"]}
           {:text ["Goodbye!"]}]
          (-> (game/start-new-game nil)
              (sut/add-message "Hello!")
              (sut/add-message "Goodbye!")
+             (continue-game)
              (get-messages))))
   (is (thrown? java.lang.IndexOutOfBoundsException
                (-> (game/start-new-game nil)
-                   (sut/add-message "Hello {0}!"))))
+                   (sut/add-message "Hello {0}!")
+                   (continue-game))))
   (is (= [{:text ["Hello" "Noah" "!"]}]
          (-> (game/start-new-game nil)
              (sut/add-message "Hello {0}!" ["Noah"])
+             (continue-game)
              (get-messages))))
   (is (= [{:text ["Hello" {:name "Noah"} "!"]}]
          (-> (game/start-new-game nil)
              (sut/add-message "Hello {0}!" [{:name "Noah"
                                              :no-match "Bogart"}])
+             (continue-game)
              (get-messages))))
   (is (= [{:text ["going" "," "going" "and" "gone" "!"]}]
          (-> (game/start-new-game nil)
              (sut/add-message "{0}, {0} and {1}!" ["going" "gone"])
+             (continue-game)
              (get-messages)))))

--- a/test/engine/pipeline_test.clj
+++ b/test/engine/pipeline_test.clj
@@ -79,60 +79,63 @@
            (:gp (sut/update-pipeline game))))))
 
 (deftest continue-gp-test
-  (testing "returns true by default"
+  (testing "does nothing by default"
     (let [game (game/new-game nil)]
-      (is (= [true game] (sut/continue-game game)))))
+      (is (= game (sut/continue-game game)))))
   (testing "updates the pipeline"
     (let [step (step/make-base-step
                  {:continue-step
-                  (fn [_step game] [false game])})
+                  (fn [_step game] game)})
           game (-> (game/new-game nil)
                    (sut/queue-step step))]
       (is (= {:pipeline [step] :queue []}
-             (:gp (second (sut/continue-game game)))))))
+             (:gp (sut/update-pipeline game))))))
   (testing "calls 'continue-step' on current step"
     (let [step (step/make-base-step
                  {:continue-step
-                  (fn [_step _game] [false :foo])})
+                  (fn [_step game] (assoc-in game [:--test-flag] :--test-value))})
           game (-> (game/new-game nil)
                    (sut/queue-step step))]
-      (is (= [false :foo] (sut/continue-game game)))))
-  (testing "drops the current step if 'continue-step' returns true"
+      (is (= :--test-value (get-in (sut/continue-game game) [:--test-flag])))))
+  (testing "drops the current step after 'continue-step'"
     (let [step (step/make-base-step
                  {:continue-step
-                  (fn [_step game] [true game])})
+                  (fn [_step game] game)})
           game (-> (game/new-game nil)
                    (sut/queue-step step)
                    (sut/continue-game))]
-      (is (= {:pipeline [] :queue []} (:gp (second game)))))))
+      (is (= {:pipeline [] :queue []} (:gp game))))))
 
 (deftest handle-prompt-clicked-test
-  (testing "returns false by default"
+  (testing "does nothing by default"
     (let [game (game/new-game nil)]
-      (is (= [false game] (sut/handle-prompt-clicked game :corp "button")))))
+      (is (= game (sut/handle-prompt-clicked game :corp "button")))))
   (testing "doesn't update the pipeline"
     (let [step (prompt/base-prompt
                  {:active-prompt (constantly {:text "text"})
-                  :active-condition :corp})
+                  :active-condition :corp
+                  :on-prompt-clicked
+                  (fn [_step game _player _button] game)})
           game (-> (game/new-game nil)
                    (sut/queue-step step))]
       (is (= {:pipeline [] :queue [step]}
              (->> (sut/handle-prompt-clicked game :corp "button")
-                  (second)
                   (:gp))))))
-  (testing "returns false if pipeline is empty"
+  (testing "does nothing if pipeline is empty"
     (let [step (prompt/base-prompt
                  {:active-prompt (constantly {:text "text"})
-                  :active-condition :corp})
+                  :active-condition :corp
+                  :on-prompt-clicked
+                  (fn [_step game _player _button] game)})
           game (-> (game/new-game nil)
                    (sut/queue-step step))]
-      (is (false? (first (sut/handle-prompt-clicked game :corp "button"))))))
+      (is (= game (sut/handle-prompt-clicked game :corp "button")))))
   (testing "calls 'on-prompt-clicked' on current step"
     (let [step (prompt/base-prompt
                  {:active-prompt (constantly {:text "text"})
                   :active-condition :corp
                   :on-prompt-clicked
-                  (fn [_step _game _player _button] [:foo :bar])})
+                  (fn [_step game _player _button] (assoc-in game [:--test-flag] :--test-check ))})
           game (-> (game/new-game nil)
                    (assoc-in [:gp :pipeline] [step]))]
-      (is (= [:foo :bar] (sut/handle-prompt-clicked game :corp "button"))))))
+      (is (= :--test-check (get-in (sut/handle-prompt-clicked game :corp "button") [:--test-flag]))))))

--- a/test/engine/pipeline_test.clj
+++ b/test/engine/pipeline_test.clj
@@ -111,7 +111,7 @@
     (let [game (game/new-game nil)]
       (is (= game (sut/handle-prompt-clicked game :corp "button")))))
   (testing "doesn't update the pipeline"
-    (let [step (prompt/base-prompt
+    (let [step (prompt/base-prompt-step
                  {:active-prompt (constantly {:text "text"})
                   :active-condition :corp
                   :on-prompt-clicked
@@ -122,7 +122,7 @@
              (->> (sut/handle-prompt-clicked game :corp "button")
                   (:gp))))))
   (testing "does nothing if pipeline is empty"
-    (let [step (prompt/base-prompt
+    (let [step (prompt/base-prompt-step
                  {:active-prompt (constantly {:text "text"})
                   :active-condition :corp
                   :on-prompt-clicked
@@ -131,7 +131,7 @@
                    (sut/queue-step step))]
       (is (= game (sut/handle-prompt-clicked game :corp "button")))))
   (testing "calls 'on-prompt-clicked' on current step"
-    (let [step (prompt/base-prompt
+    (let [step (prompt/base-prompt-step
                  {:active-prompt (constantly {:text "text"})
                   :active-condition :corp
                   :on-prompt-clicked

--- a/test/engine/steps/action_phase_test.clj
+++ b/test/engine/steps/action_phase_test.clj
@@ -11,17 +11,15 @@
 (deftest action-phase-prompt-test
   (is (= "You have 3 clicks. Choose an action."
          (-> (game/new-game nil)
-             (pipeline/queue-step (sut/action-phase :corp))
+             (sut/action-phase :corp)
              (pipeline/continue-game)
-             (second)
              (prompt-state/prompt-text :corp)))))
 
 (deftest action-phase-buttons-test
   (is (= 1
          (-> (game/new-game nil)
-             (pipeline/queue-step (sut/action-phase :corp))
+             (sut/action-phase :corp)
              (pipeline/continue-game)
-             (second)
              (click-prompt :corp "[click] Gain 1[c].")
              (:corp)
              (player/credits)))))

--- a/test/engine/steps/action_phase_test.clj
+++ b/test/engine/steps/action_phase_test.clj
@@ -17,7 +17,7 @@
 
 (deftest action-phase-buttons-test
   (is (= 1
-         (-> (game/new-game nil)
+         (-> (game/new-game {:corp {:credits 0}})
              (sut/action-phase :corp)
              (pipeline/continue-game)
              (click-prompt :corp "[click] Gain 1[c].")

--- a/test/engine/steps/base_step_test.clj
+++ b/test/engine/steps/base_step_test.clj
@@ -5,17 +5,17 @@
 
 (deftest base-step-test
   (is (thrown? clojure.lang.ExceptionInfo (sut/validate (sut/map->BaseStep {}))))
-  (let [continue-fn (constantly [true false])
+  (let [continue-fn (constantly false)
         step (sut/make-base-step {:continue-step continue-fn})]
-    (is (= [true false] (sut/continue-step step {}))))
+    (is (= false (sut/continue-step step {}))))
   (let [continue-fn (fn [step game] [step game])
         game {:a 1}
         step (sut/make-base-step {:continue-step continue-fn})]
-    (is (= [step game] (sut/continue-step step game))))
-  (is (not (sut/complete? (sut/make-base-step nil)))))
+    (is (= [step game] (sut/continue-step step game)))
+    (is (not (sut/blocking (sut/make-base-step nil) game)))))
 
 (deftest simple-step-test
-  (is (= [true :foo]
+  (is (= :foo
          (sut/continue-step
            (sut/simple-step (fn [game] game))
            :foo))))

--- a/test/engine/steps/draw_phase_test.clj
+++ b/test/engine/steps/draw_phase_test.clj
@@ -9,9 +9,8 @@
 (deftest draw-if-corp-test
   (let [game (-> (game/new-game {:corp {:user {:username "Corp player"}
                                         :deck ["Hedge Fund"]}})
-                 (pipeline/queue-step (sut/draw-phase))
-                 (pipeline/continue-game)
-                 (second))]
+                 (sut/draw-phase)
+                 (pipeline/continue-game))]
     (is (= 1 (-> game
                  (get-in [:corp :hand])
                  (count))))
@@ -19,8 +18,7 @@
            (-> game
                (get-messages)))))
   (is (= 0 (-> (game/new-game {:runner {:deck ["Sure Gamble"]}})
-               (pipeline/queue-step (sut/draw-phase))
+               (sut/draw-phase)
                (pipeline/continue-game)
-               (second)
                (get-in [:corp :hand])
                (count)))))

--- a/test/engine/steps/effect_test.clj
+++ b/test/engine/steps/effect_test.clj
@@ -6,7 +6,7 @@
    [engine.steps.step :as step]
    [engine.steps.effect :as sut]
    [engine.test-helper :refer [click-prompt]]))
-   
+
 (deftest defeffect-macro-test
   (let [test-effect (macroexpand `(sut/defeffect-full ~'test-effect ~'[game t a] ~'(-> game (blah t) (blah a))))]
     (testing "wraps in do"
@@ -21,8 +21,3 @@
       (is (not (thrown? Exception (test-effect {} nil nil)))))
     (testing "Creates the unsafe function"
       (is (not (thrown? Exception (test-effect-unsafe {} nil nil)))))))
-
-
-
-;(deftest defeffect-macro-test
-  

--- a/test/engine/steps/effect_test.clj
+++ b/test/engine/steps/effect_test.clj
@@ -1,0 +1,28 @@
+(ns engine.steps.effect-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [engine.game :as game]
+   [engine.pipeline :as pipeline]
+   [engine.steps.step :as step]
+   [engine.steps.effect :as sut]
+   [engine.test-helper :refer [click-prompt]]))
+   
+(deftest defeffect-macro-test
+  (let [test-effect (macroexpand `(sut/defeffect-full ~'test-effect ~'[game t a] ~'(-> game (blah t) (blah a))))]
+    (testing "wraps in do"
+      (is (= 'do (first test-effect))))
+    (testing "contains a definition of the main function"
+      (is (some #(= '(clojure.core/defn test-effect) (take 2 %)) (rest test-effect))))
+    (testing "contains a definition of the unsafe function"
+      (is (some #(= '(clojure.core/defn test-effect-unsafe) (take 2 %)) (rest test-effect)))))
+  (comment "These test were my first thought but rather than actually define things with it I feel it's better to check the results of the macro directly"
+    (sut/defeffect-full test-effect [game t a] game);Doing this in a test irks me a little but...
+    (testing "Creates the main function"
+      (is (not (thrown? Exception (test-effect {} nil nil)))))
+    (testing "Creates the unsafe function"
+      (is (not (thrown? Exception (test-effect-unsafe {} nil nil)))))))
+
+
+
+;(deftest defeffect-macro-test
+  

--- a/test/engine/steps/let_step_test.clj
+++ b/test/engine/steps/let_step_test.clj
@@ -1,0 +1,28 @@
+(ns engine.steps.let-step-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [engine.game :as game]
+   [engine.pipeline :as pipeline]
+   [engine.macros :as sut]))
+
+;This should also check things are ordered correctly and nil defaults
+;I'm not thrilled with this style of testing though, putting is inside of steps seems wrong. What if the step doesn't run at all? but it's hard to test var binding otherwise, maybe atoms?
+
+(deftest let-step-test
+  (let [game (game/new-game {})]
+    (testing "Basic test"
+      (let [game (-> game
+                     (sut/let-step [test-var (sut/set-result game :--test-flag)]
+                                   (is (= test-var :--test-flag))
+                                   (assoc-in game [:--test-loc2] :--test-flag2)
+                     (pipeline/continue-game)))]
+        (is "Test steps were executed" (= :--test-flag2 (get-in game [:--test-loc2])))))
+    (testing "Multiple bindings test"
+      (let [game (-> game
+                     (sut/let-step [test-var1 (sut/set-result game :--test-flag1)
+                                    test-var2 (sut/set-result game :--test-flag2)]
+                                   (is (= test-var1 :--test-flag1))
+                                   (is (= test-var2 :--test-flag2))
+                                   (assoc-in game [:--test-loc3] :--test-flag3))
+                     (pipeline/continue-game))]
+        (is "Test steps were executed" (= :--test-flag3 (get-in game [:--test-loc3])))))))

--- a/test/engine/steps/mulligan_step_test.clj
+++ b/test/engine/steps/mulligan_step_test.clj
@@ -11,13 +11,12 @@
           {:text [{:name "Corp player"} "draws 1 card for their mandatory draw."]}]
          (-> (game/start-new-game {:corp {:user {:username "Corp player"}}
                                    :runner {:user {:username "Runner player"}}})
-             (second)
              (click-prompt :corp "Keep")
              (click-prompt :runner "Keep")
              (get-messages)))))
 
 (deftest mulligan-prompt-test
-  (let [game (second (game/start-new-game nil))]
+  (let [game (game/start-new-game nil)]
     (is (= "Mulligan"
            (prompt-state/prompt-header game :corp)))
     (is (= "Keep or mulligan this hand?"

--- a/test/engine/steps/phase_test.clj
+++ b/test/engine/steps/phase_test.clj
@@ -7,19 +7,16 @@
    [engine.steps.step :as step]
    [engine.steps.phase :as sut]))
 
-(deftest initialize-steps-test
-  (is (= 2 (count (sut/initialize-steps nil))))
-  (is (= 3 (count (sut/initialize-steps
-                    {:steps [(step/simple-step (constantly :foo))]})))))
-
 (deftest queue-steps-test
   (let [step1 (step/simple-step (fn [g] g))
         step2 (step/simple-step (fn [g] g))
         step3 (step/simple-step (fn [g] g))]
     (is (= [step1 step2 step3]
            (-> (game/new-game nil)
-               (sut/queue-phase-steps [#(pipeline/queue-step % step1) #(pipeline/queue-step % step2) #(pipeline/queue-step % step3)])
-               (get-in [:gp :queue]))))))
+               (sut/queue-phase-steps {:steps #(-> % (pipeline/queue-step step1) (pipeline/queue-step step2) (pipeline/queue-step step3))})
+               (get-in [:gp :queue])
+               (rest)
+               (drop-last))))))
 
 (deftest make-phase-test
   (let [step1 (step/simple-step (fn [g] g))
@@ -37,7 +34,7 @@
     (testing "steps are queued"
       (is (= 4 (-> (game/new-game nil)
                    (pipeline/queue-step (sut/make-phase
-                                      {:steps [block-step #(pipeline/queue-step % step1) #(pipeline/queue-step % step2)]}))
+                                      {:steps #(-> % (block-step) (pipeline/queue-step step1) (pipeline/queue-step step2))}))
                    (pipeline/continue-game)
                    (get-in [:gp :pipeline])
                    (count)))))
@@ -45,7 +42,7 @@
            (-> (game/new-game nil)
                (pipeline/queue-step (sut/make-phase
                                   {:phase :phase/start-of-turn
-                                   :steps [block-step]}))
+                                   :steps block-step}))
                (pipeline/continue-game)
                (:current-phase))))
     (is (nil? (-> (game/new-game nil)

--- a/test/engine/steps/phase_test.clj
+++ b/test/engine/steps/phase_test.clj
@@ -3,7 +3,7 @@
    [clojure.test :refer [deftest is testing]]
    [engine.game :as game]
    [engine.pipeline :as pipeline]
-   [engine.test-helper :refer [block-step]]
+   [engine.test-helper :refer [block]]
    [engine.steps.step :as step]
    [engine.steps.phase :as sut]))
 
@@ -14,6 +14,12 @@
     (is (= [step1 step2 step3]
            (-> (game/new-game nil)
                (sut/queue-phase-steps {:steps #(-> % (pipeline/queue-step step1) (pipeline/queue-step step2) (pipeline/queue-step step3))})
+               (get-in [:gp :queue])
+               (rest)
+               (drop-last))))
+    (is (= [step1 step2 step3]
+           (-> (game/new-game nil)
+               (sut/queue-phase-steps {:steps [#(pipeline/queue-step % step1) #(pipeline/queue-step % step2) #(pipeline/queue-step % step3)]})
                (get-in [:gp :queue])
                (rest)
                (drop-last))))))
@@ -34,7 +40,7 @@
     (testing "steps are queued"
       (is (= 4 (-> (game/new-game nil)
                    (pipeline/queue-step (sut/make-phase
-                                      {:steps #(-> % (block-step) (pipeline/queue-step step1) (pipeline/queue-step step2))}))
+                                      {:steps #(-> % (block) (pipeline/queue-step step1) (pipeline/queue-step step2))}))
                    (pipeline/continue-game)
                    (get-in [:gp :pipeline])
                    (count)))))
@@ -42,7 +48,7 @@
            (-> (game/new-game nil)
                (pipeline/queue-step (sut/make-phase
                                   {:phase :phase/start-of-turn
-                                   :steps block-step}))
+                                   :steps block}))
                (pipeline/continue-game)
                (:current-phase))))
     (is (nil? (-> (game/new-game nil)

--- a/test/engine/steps/phase_test.clj
+++ b/test/engine/steps/phase_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer [deftest is testing]]
    [engine.game :as game]
    [engine.pipeline :as pipeline]
+   [engine.test-helper :refer [block-step]]
    [engine.steps.step :as step]
    [engine.steps.phase :as sut]))
 
@@ -17,14 +18,12 @@
         step3 (step/simple-step (fn [g] g))]
     (is (= [step1 step2 step3]
            (-> (game/new-game nil)
-               (sut/queue-phase-steps [step1 step2 step3])
+               (sut/queue-phase-steps [#(pipeline/queue-step % step1) #(pipeline/queue-step % step2) #(pipeline/queue-step % step3)])
                (get-in [:gp :queue]))))))
 
 (deftest make-phase-test
-  (let [step1 (step/make-base-step
-                {:continue-step (fn [_ g] [false g])})
-        step2 (step/simple-step (fn [g] g))
-        step3 (step/simple-step (fn [g] g))]
+  (let [step1 (step/simple-step (fn [g] g))
+        step2 (step/simple-step (fn [g] g))]
     (is (= 1 (-> (game/new-game nil)
                  (pipeline/queue-step (sut/make-phase))
                  (get-in [:gp :queue])
@@ -38,22 +37,19 @@
     (testing "steps are queued"
       (is (= 4 (-> (game/new-game nil)
                    (pipeline/queue-step (sut/make-phase
-                                      {:steps [step1 step2 step3]}))
+                                      {:steps [block-step #(pipeline/queue-step % step1) #(pipeline/queue-step % step2)]}))
                    (pipeline/continue-game)
-                   (second)
                    (get-in [:gp :pipeline])
                    (count)))))
     (is (= :phase/start-of-turn
            (-> (game/new-game nil)
                (pipeline/queue-step (sut/make-phase
                                   {:phase :phase/start-of-turn
-                                   :steps [step1]}))
+                                   :steps [block-step]}))
                (pipeline/continue-game)
-               (second)
                (:current-phase))))
     (is (nil? (-> (game/new-game nil)
                   (pipeline/queue-step (sut/make-phase
                                      {:phase :phase/start-of-turn}))
                   (pipeline/continue-game)
-                  (second)
                   (:current-phase))))))

--- a/test/engine/steps/prompt_test.clj
+++ b/test/engine/steps/prompt_test.clj
@@ -22,14 +22,14 @@
                   :active-prompt active-prompt
                   :waiting-text waiting-text
                   :on-prompt-clicked (fn [_step game _player _button] game)}
-                 (sut/base-prompt)
+                 (sut/base-prompt-step)
                  (select-keys [:active-condition :active-prompt
                                :waiting-prompt :type])))))
     (testing "waiting-prompt has a default"
       (is (= (-> {:active-condition :corp
                   :active-prompt (constantly {:title "yes"})
                   :on-prompt-clicked (fn [_step game _player _button] game)}
-                 (sut/base-prompt)
+                 (sut/base-prompt-step)
                  (:waiting-prompt))
              {:text "Waiting for opponent"})))))
 
@@ -38,7 +38,7 @@
                          :text "Example text"}
           waiting-text "Waiting text"
           waiting-prompt {:text waiting-text}
-          step (sut/base-prompt
+          step (sut/base-prompt-step
                  {:active-condition :corp
                   :active-prompt (constantly active-prompt)
                   :waiting-text waiting-text
@@ -58,7 +58,7 @@
     (let [active-prompt {:header "Example header"
                          :text "Example text"}
           waiting-text "Waiting text"
-          step (sut/base-prompt
+          step (sut/base-prompt-step
                  {:active-condition :corp
                   :active-prompt (constantly active-prompt)
                   :waiting-text waiting-text
@@ -74,7 +74,7 @@
   (testing "continue calls into set-prompt"
     (let [active-prompt {:header "Example header"
                          :text "Example text"}
-          step (sut/base-prompt
+          step (sut/base-prompt-step
                  {:active-condition :corp
                   :active-prompt (constantly active-prompt)
                   :on-prompt-clicked (fn [_step game _player _button] game)})
@@ -90,7 +90,7 @@
   (testing "player prompts are restored after step is complete"
     (let [active-prompt {:header "Example header"
                          :text "Example text"}
-          step (sut/base-prompt
+          step (sut/base-prompt-step
                  {:active-condition :corp
                   :active-prompt (constantly active-prompt)
                   :on-prompt-clicked (fn [_step game _player _button] game)})
@@ -103,7 +103,7 @@
       (is (= "" (get-in runner [:prompt-state :text]))))))
 
 (deftest prompt-with-handlers-test
-  (let [step (sut/handler-prompt
+  (let [step (sut/handler-prompt-step
                {:active-condition :corp
                 :active-text "How many to draw?"
                 :waiting-text "Corp to draw"

--- a/test/engine/steps/setup_phase_test.clj
+++ b/test/engine/steps/setup_phase_test.clj
@@ -9,40 +9,35 @@
 (deftest setup-test
   (is (= :phase/setup
          (-> (game/new-game nil)
-             (pipeline/queue-step (sut/setup-phase))
+             (sut/setup-phase)
              (pipeline/continue-game)
-             (second)
              (:current-phase))))
   (testing "both players shuffle their decks"
     (with-redefs [clojure.core/shuffle (comp #(into [] %) reverse)]
       (is (= [:d :c :b :a]
              (-> (game/new-game {:corp {:deck [:a :b :c :d :e :f :g :h :i]}})
-                 (pipeline/queue-step (sut/setup-phase))
+                 (sut/setup-phase)
                  (pipeline/continue-game)
-                 (second)
                  (get-in [:corp :deck]))))))
   (testing "both players draw 5 cards"
     (is (= 5
            (-> (game/new-game {:corp {:deck [:a :b :c :d :e :f :g :h :i]}})
-               (pipeline/queue-step (sut/setup-phase))
+               (sut/setup-phase)
                (pipeline/continue-game)
-               (second)
                (get-in [:corp :hand])
                (count))))
     (is (= 5
            (-> (game/new-game {:runner {:deck [:a :b :c :d :e :f :g :h :i]}})
-               (pipeline/queue-step (sut/setup-phase))
+               (sut/setup-phase)
                (pipeline/continue-game)
-               (second)
                (get-in [:runner :hand])
                (count))))))
 
 (deftest mulligan-tests
   (testing "mulligan prompts display correctly"
     (let [game (-> (game/new-game {:corp {:deck [:a :b :c :d :e :f :g :h :i]}})
-                   (pipeline/queue-step (sut/setup-phase))
-                   (pipeline/continue-game)
-                   (second))]
+                   (sut/setup-phase)
+                   (pipeline/continue-game))]
       (is (= {:header "Mulligan"
               :text "Keep or mulligan this hand?"
               :buttons [{:text "Keep"

--- a/test/engine/steps/start_of_turn_phase_test.clj
+++ b/test/engine/steps/start_of_turn_phase_test.clj
@@ -11,7 +11,6 @@
   (is (= :corp
          (-> (game/start-new-game {:corp {:deck [:a :b :c :d :e :f :g :h :i]}
                                    :runner {:deck [:a :b :c :d :e :f :g :h :i]}})
-             (second)
              (click-prompt :corp "Keep")
              (click-prompt :runner "Keep")
              (:active-player)))))
@@ -19,14 +18,12 @@
 (deftest gain-allotted-clicks-test
   (is (= (:clicks-per-turn (player/new-corp nil))
          (-> (game/new-game nil)
-             (pipeline/queue-step (sut/gain-allotted-clicks))
+             (sut/gain-allotted-clicks)
              (pipeline/continue-game)
-             (second)
              (get-in [:corp :clicks]))))
   (is (= (:clicks-per-turn (player/new-runner nil))
          (-> (game/new-game nil)
              (assoc :active-player :runner)
-             (pipeline/queue-step (sut/gain-allotted-clicks))
+             (sut/gain-allotted-clicks)
              (pipeline/continue-game)
-             (second)
              (get-in [:runner :clicks])))))

--- a/test/engine/steps/step_protocol_test.clj
+++ b/test/engine/steps/step_protocol_test.clj
@@ -9,7 +9,7 @@
   (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Step <.*> is not a valid step" (sut/continue-step nil nil)))
   (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Step <.*> is not a valid step" (sut/continue-step {} nil))))
 
-(deftest step-protocol-complete?-test
+(deftest step-protocol-blocking-test
   (is (thrown? clojure.lang.ExceptionInfo (sut/blocking nil {})))
   (is (thrown? clojure.lang.ExceptionInfo (sut/blocking {} {})))
   (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Step <.*> is not a valid step" (sut/blocking nil {})))

--- a/test/engine/steps/step_protocol_test.clj
+++ b/test/engine/steps/step_protocol_test.clj
@@ -10,10 +10,10 @@
   (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Step <.*> is not a valid step" (sut/continue-step {} nil))))
 
 (deftest step-protocol-complete?-test
-  (is (thrown? clojure.lang.ExceptionInfo (sut/complete? nil)))
-  (is (thrown? clojure.lang.ExceptionInfo (sut/complete? {})))
-  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Step <.*> is not a valid step" (sut/complete? nil)))
-  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Step <.*> is not a valid step" (sut/complete? {}))))
+  (is (thrown? clojure.lang.ExceptionInfo (sut/blocking nil {})))
+  (is (thrown? clojure.lang.ExceptionInfo (sut/blocking {} {})))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Step <.*> is not a valid step" (sut/blocking nil {})))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Step <.*> is not a valid step" (sut/blocking {} {}))))
 
 (deftest step-protocol-validate-test
   (is (thrown? clojure.lang.ExceptionInfo (sut/validate nil)))

--- a/test/engine/test_helper.clj
+++ b/test/engine/test_helper.clj
@@ -19,9 +19,7 @@ step/Step
 (continue-step [this game] game)
 (validate [this] true))
 
-
-
-(defn block-step
+(defn block
   [game]
   (pipeline/queue-step game (BlockStep. (java.util.UUID/randomUUID))))
 


### PR DESCRIPTION
So, whole bunch of stuff. Most importantly I think is the idea of a split between "effect steps" that alter game state and steps that don't. "Alter the game state" is taken very strictly. They must directly immediately alter in game state, adding things to the queue never counts. Drawing cards is an effect. Drawing until your hand is full is not, because it can just queue up a draw effect. It should be a single unit of change and we should strive to define as few effects as possible. 

The term "effect step" has nothing to do with any records and macros that help you make them. If it alters the game state it's an effect step by definition (we could maybe have a term for things like the game log that aren't but should be handled the same). What this really means is if you want in game changes you must always queue them. This means there's always the chance for things like prompts to inject themselves, but more importantly doing it with all effects ensures that they're always intuitively ordered. Taking this principle a step further, if it doesn't alter the state and also doesn't examine the state, we don't have to care if it's a step or not. Running now and adding steps to the queue, versus being queued as a step now and adding those steps when it's your turn is always the same difference. This means you can safely go from something like (clicked-card "sure gamble") to (pay-cost 5) (gain-credits 9) in a single iteration of continue-game. 

It's at this point I really have to argue again for a game& -> game signature and the convention of helper functions to queue things for you rather than build steps for you to queue. Without functions that tend to queue for you, we basically can't use that property. The onus would be on the caller to either queue something as a step or call it directly. With them you can just thread game through any function. The real advantage though is that it completes the illusion that was started by declaring that all effects (and prompts ofc) must be queued. It lets you pretend that this is synchronous code with no pipeline, that queuing something is the same as running it now, that prompts really do block and that (queue-step this) is (recur). This is a very solid relationship, unless you're doing something like examining the stack trace, so long as you follow the rule of no changing state directly, the code will act identically (details in doc). 

It's also just nice to have everything thread game. It means you can write simple functions with defn to begin with. Then, if you want to update them so they run as a step you can just replace defn with defstep. If you want to make it an effect, replace defstep with defeffect. If you want automatic triggers, interrupts and prevention defeffect-full. 

Which brings us nicely to the automatic triggers stuff. I'm pretty confident I can make a macro that takes a simple function like your draw function and automates the rest. Initially I had the macro creating a DrawStep record etc, but I think a big macro like that is hell to maintain. The new version uses a small macro that wraps tightly around a generic EffectStep record. A final version would use a library like defntly to mimic all of defns options and have its own set of modifiers. 

I've "implemented" prevention effects (with a dummy check) so when you write (-> game (draw :runner 3) that queues an EffectStep that checks for prevention effects before it runs the draw function, obviously as with the rest of it it's just an example to show where I'm coming from. One thing I haven't written yet but I would like to mention is a plan for a true interrupt system. I think we can actually do what the CR says we should wrt finding the expected effects. All I have to do is be a massive hypocrite and this should allow us to time travel into the future. I kid, but the idea is we set :expected-effects in game to an empty list, then recur into continue-game. Any interruptable effects that run will automatically add themselves to this list if it exists and it will cause checkpoints to halt execution. Once continue-game has finished, we extract the list and discard the rest. So we've built an automatic list of all the interruptable effects that will happen before the next checkpoint. Then check it against active interrupts etc etc. This can all (including knowing when we need to check this) be handled transparently from within EffectStep itself (full process in doc). 

There's also a let-step macro and a set-result function to handle the results of steps. So you can do (-> game (let-step [cards-drawn (draw game... even though draw is now defined as a step that is queued and like all steps it just threads game, it now calls (set-result amount) as the final function in its thread. Of course the body of your let-step is also being queued so it runs after the draw, when the results are available. Note that let-step is for getting results from queuable things that thread game (i.e. effects), just use (as-step (let for normal state reporting. 

There's a few other random things, like small refactors or error handling to dump the game state and generally moving it over to always threading game through everything, note that (outside of my small refactors) the structure hasn't changed t all, but none of the code changes are nearly as important as the general concept of being careful about queueing state changes. It's this that means that you stop having to reason about the pipeline directly. Let me know what you think of the concept of effect steps and more generally about the idea of supporting this mental shortcut that the code is synchronous. I go into more detail about it in a draft docs (that's really more random notes) including proposing the term "core" as the stuff that interacts directly with the pipeline. 

The core is pretty much fully implemented, it's just the primitive steps and a few macros that wrap around simple-step. It needs some polishing of course but once it's in place it should need very little extension or maintanence. Everything else can be written as if it were synchronous, you just have to replace the right things with those macros (details in the doc) and you're guaranteed to get identical results. For instance source of abilities could be implemented with: 

(defstep ab-with-source [game ability source]
  (let [old-source (get-source game)]
	(-> game (set-source source)
			 (do-ability ability)
			 (set-source old-source))))

Where set-source is also defined with defstep. Without having to dig into what's going on in the pipeline or what it is that the ability is doing we can be sure that source is set and reset either side of the ability resolving, regardless of any prompts or whatever that the ability causes. It would work if this were synchronous, so it will work here. 

The interrupts system is kinda on the border of core/engine. It does interact with the pipeline to call continue-game and it does define its own step record because it's easier than trying to use simple steps, but it's still written in a synchronous style. Interrupts is where I want to look next, make sure we can implement them in a transparent way. If that goes well the big gotchas in the engine are abstracted away and we should have a relatively easy time of writing a basically synchronous set of game/card rules. 